### PR TITLE
Structure block limits

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -89,6 +89,7 @@ public class CarpetSettings
     public static boolean doubleRetraction = false;
     public static boolean netherRNG = false;
     public static boolean endRNG = false;
+    public static int structureBlockLimit = 32;
 
     public static long setSeed = 0;
 
@@ -264,6 +265,8 @@ public class CarpetSettings
                                 .extraInfo("As set by the /tickingarea comamnd.",
                                 "Ticking areas work as if they are the spawn chunks."),
   rule("disableSpawnChunks",    "creative", "Removes the spawn chunks."),
+  rule("structureBlockLimit",   "creative", "Changes the structure block dimension limit.")
+                                .choices("32", "32 50 200 1000").setNotStrict(),
 
         };
         for (CarpetSettingEntry rule: RuleList)
@@ -305,6 +308,7 @@ public class CarpetSettings
         doubleRetraction = CarpetSettings.getBool("doubleRetraction");
         netherRNG = CarpetSettings.getBool("netherRNG");
         endRNG = CarpetSettings.getBool("endRNG");
+        structureBlockLimit = CarpetSettings.getInt("structureBlockLimit");
 
         if ("pistonGhostBlocksFix".equalsIgnoreCase(rule))
         {

--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -211,6 +211,7 @@ public class CarpetSettings
   rule("commandPerimeterInfo",  "commands", "Enables /perimeterinfo command that scans the area around the block for potential spawnable spots").defaultTrue(),
   rule("commandPlayer",         "commands", "Enables /player command to control/spawn players").defaultTrue(),
   rule("commandRNG",            "commands", "Enables /rng command to manipulate and query rng").defaultTrue(),
+  rule("commandStructure",      "commands", "Enables /structure to manage NBT structures used by structure blocks").defaultTrue(),
   rule("newLight",              "optimizations", "Uses alternative lighting engine by PhiPros. AKA NewLight mod"),
   rule("carpets",               "survival", "Placing carpets may issue carpet commands for non-op players"),
   rule("missingTools",          "survival", "Pistons, Glass and Sponge can be broken faster with their appropriate tools"),

--- a/carpetmodSrc/carpet/commands/CommandStructure.java
+++ b/carpetmodSrc/carpet/commands/CommandStructure.java
@@ -23,6 +23,7 @@ import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.init.Blocks;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatAllowedCharacters;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
@@ -84,8 +85,11 @@ public class CommandStructure extends CommandCarpetBase
         if (args.length < 2)
             throw new WrongUsageException(USAGE_LOAD);
         
+        String structureName = args[1];
+        for (char illegal : ChatAllowedCharacters.ILLEGAL_STRUCTURE_CHARACTERS)
+            structureName = structureName.replace(illegal, '_');
         TemplateManager manager = server.worlds[0].getStructureTemplateManager();
-        Template template = manager.get(server, new ResourceLocation(args[1]));
+        Template template = manager.get(server, new ResourceLocation(structureName));
         if (template == null)
             throw new CommandException("Template \"" + args[1] + "\" doesn't exist");
         
@@ -187,13 +191,16 @@ public class CommandStructure extends CommandCarpetBase
             ignoreEntities = parseBoolean(args[8]);
         }
         
+        String structureName = args[1];
+        for (char illegal : ChatAllowedCharacters.ILLEGAL_STRUCTURE_CHARACTERS)
+            structureName = structureName.replace(illegal, '_');
         TemplateManager manager = server.worlds[0].getStructureTemplateManager();
-        Template template = manager.getTemplate(server, new ResourceLocation(args[1]));
+        Template template = manager.getTemplate(server, new ResourceLocation(structureName));
         template.takeBlocksFromWorld(sender.getEntityWorld(), origin, size, !ignoreEntities, Blocks.STRUCTURE_VOID);
         template.setAuthor(sender.getName());
-        manager.writeTemplate(server, new ResourceLocation(args[1]));
+        manager.writeTemplate(server, new ResourceLocation(structureName));
         
-        notifyCommandListener(sender, this, "Successfully saved structure " + args[1]);
+        notifyCommandListener(sender, this, "Successfully saved structure " + structureName);
     }
     
     private void listStructure(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException

--- a/carpetmodSrc/carpet/commands/CommandStructure.java
+++ b/carpetmodSrc/carpet/commands/CommandStructure.java
@@ -228,9 +228,12 @@ public class CommandStructure extends CommandCarpetBase
         Path baseFolder = Paths.get(manager.baseFolder);
         try
         {
-            Files.find(baseFolder, Integer.MAX_VALUE,
-                    (path, attr) -> attr.isRegularFile() && path.getFileName().toString().endsWith(".nbt"))
-            .forEach(path -> templates.add(baseFolder.relativize(path).toString().replace(File.separator, "/").replace(".nbt", "")));
+            if (Files.exists(baseFolder))
+            {
+                Files.find(baseFolder, Integer.MAX_VALUE,
+                        (path, attr) -> attr.isRegularFile() && path.getFileName().toString().endsWith(".nbt"))
+                .forEach(path -> templates.add(baseFolder.relativize(path).toString().replace(File.separator, "/").replace(".nbt", "")));
+            }
         }
         catch (IOException e)
         {

--- a/carpetmodSrc/carpet/commands/CommandStructure.java
+++ b/carpetmodSrc/carpet/commands/CommandStructure.java
@@ -1,0 +1,334 @@
+package carpet.commands;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.init.Blocks;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.Mirror;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Rotation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.gen.structure.StructureBoundingBox;
+import net.minecraft.world.gen.structure.template.PlacementSettings;
+import net.minecraft.world.gen.structure.template.Template;
+import net.minecraft.world.gen.structure.template.TemplateManager;
+
+public class CommandStructure extends CommandCarpetBase
+{
+
+    private static final String USAGE = "/structure <load|save|list> ...";
+    private static final String USAGE_LOAD = "/structure load <name> [pos: x y z] [mirror] [rotation] [ignoreEntities] [integrity] [seed]";
+    private static final String USAGE_SAVE = "/structure save <name> <from: x y z> <to: x y z> [ignoreEntities]";
+    
+    @Override
+    public String getName()
+    {
+        return "structure";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender)
+    {
+        return USAGE;
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
+    {
+        if (!command_enabled("commandStructure", sender))
+            return;
+        
+        if (args.length < 1)
+            throw new WrongUsageException(USAGE);
+        
+        switch (args[0])
+        {
+        case "load":
+            loadStructure(server, sender, args);
+            break;
+        case "save":
+            saveStructure(server, sender, args);
+            break;
+        case "list":
+            listStructure(server, sender, args);
+            break;
+        default:
+            throw new WrongUsageException(USAGE);
+        }
+    }
+    
+    private void loadStructure(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
+    {
+        if (args.length < 2)
+            throw new WrongUsageException(USAGE_LOAD);
+        
+        TemplateManager manager = server.worlds[0].getStructureTemplateManager();
+        Template template = manager.get(server, new ResourceLocation(args[1]));
+        if (template == null)
+            throw new CommandException("Template \"" + args[1] + "\" doesn't exist");
+        
+        BlockPos origin = sender.getPosition();
+        if (args.length >= 5)
+        {
+            origin = parseBlockPos(sender, args, 2, false);
+        }
+        
+        Mirror mirror = Mirror.NONE;
+        if (args.length >= 6)
+        {
+            switch (args[5])
+            {
+            case "no_mirror":
+                mirror = Mirror.NONE;
+                break;
+            case "mirror_left_right":
+                mirror = Mirror.LEFT_RIGHT;
+                break;
+            case "mirror_front_back":
+                mirror = Mirror.FRONT_BACK;
+                break;
+            default:
+                throw new CommandException("Unknown mirror: " + args[5]);
+            }
+        }
+        
+        Rotation rotation = Rotation.NONE;
+        if (args.length >= 7)
+        {
+            switch (args[6])
+            {
+            case "rotate_0":
+                rotation = Rotation.NONE;
+                break;
+            case "rotate_90":
+                rotation = Rotation.CLOCKWISE_90;
+                break;
+            case "rotate_180":
+                rotation = Rotation.CLOCKWISE_180;
+                break;
+            case "rotate_270":
+                rotation = Rotation.COUNTERCLOCKWISE_90;
+                break;
+            default:
+                throw new CommandException("Unknown rotation: " + args[6]);
+            }
+        }
+        
+        boolean ignoreEntities = true;
+        if (args.length >= 8)
+        {
+            ignoreEntities = parseBoolean(args[7]);
+        }
+        
+        float integrity = 1;
+        if (args.length >= 9)
+        {
+            integrity = (float) parseDouble(args[8], 0, 1);
+        }
+        
+        long seed;
+        if (args.length >= 10)
+        {
+            seed = parseLong(args[9]);
+        }
+        else
+        {
+            seed = new Random().nextLong();
+        }
+        
+        PlacementSettings settings = new PlacementSettings().setMirror(mirror).setRotation(rotation).setIgnoreEntities(ignoreEntities).setChunk(null).setReplacedBlock(null).setIgnoreStructureBlock(false);
+        if (integrity < 1)
+        {
+            settings.setIntegrity(integrity).setSeed(seed);
+        }
+        
+        template.addBlocksToWorldChunk(sender.getEntityWorld(), origin, settings);
+        
+        notifyCommandListener(sender, this, "Successfully loaded structure " + args[1]);
+    }
+    
+    private void saveStructure(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
+    {
+        if (args.length < 8)
+            throw new WrongUsageException(USAGE_SAVE);
+        
+        BlockPos pos1 = parseBlockPos(sender, args, 2, false);
+        BlockPos pos2 = parseBlockPos(sender, args, 5, false);
+        
+        StructureBoundingBox bb = new StructureBoundingBox(pos1, pos2);
+        BlockPos origin = new BlockPos(bb.minX, bb.minY, bb.minZ);
+        BlockPos size = new BlockPos(bb.getXSize(), bb.getYSize(), bb.getZSize());
+        
+        boolean ignoreEntities = true;
+        if (args.length >= 9)
+        {
+            ignoreEntities = parseBoolean(args[8]);
+        }
+        
+        TemplateManager manager = server.worlds[0].getStructureTemplateManager();
+        Template template = manager.getTemplate(server, new ResourceLocation(args[1]));
+        template.takeBlocksFromWorld(sender.getEntityWorld(), origin, size, !ignoreEntities, Blocks.STRUCTURE_VOID);
+        template.setAuthor(sender.getName());
+        manager.writeTemplate(server, new ResourceLocation(args[1]));
+        
+        notifyCommandListener(sender, this, "Successfully saved structure " + args[1]);
+    }
+    
+    private void listStructure(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
+    {
+        TemplateManager manager = server.worlds[0].getStructureTemplateManager();
+        List<String> templates = listStructures(manager);
+        
+        if (templates.isEmpty())
+        {
+            sender.sendMessage(new TextComponentString("There are no saved structures yet"));
+        }
+        else
+        {
+            final int PAGE_SIZE = 9;
+            int pageCount = (templates.size() + PAGE_SIZE - 1) / PAGE_SIZE;
+            int page = args.length >= 2 ? parseInt(args[1]) - 1 : 0;
+            page = MathHelper.clamp(page, 0, pageCount - 1);
+            
+            sender.sendMessage(new TextComponentString(TextFormatting.GREEN + "Structure list page " + (page + 1) + " of " + pageCount + " (/structure list <page>)"));
+            for (int offset = 0; offset < PAGE_SIZE && page * PAGE_SIZE + offset < templates.size(); offset++)
+            {
+                String template = templates.get(page * PAGE_SIZE + offset);
+                sender.sendMessage(new TextComponentString("- " + template + " by " + manager.get(server, new ResourceLocation(template)).getAuthor()));
+            }
+        }
+    }
+    
+    private static List<String> listStructures(TemplateManager manager)
+    {
+        List<String> templates = new ArrayList<>();
+        
+        Path baseFolder = Paths.get(manager.baseFolder);
+        try
+        {
+            Files.find(baseFolder, Integer.MAX_VALUE,
+                    (path, attr) -> attr.isRegularFile() && path.getFileName().toString().endsWith(".nbt"))
+            .forEach(path -> templates.add(baseFolder.relativize(path).toString().replace(File.separator, "/").replace(".nbt", "")));
+        }
+        catch (IOException e)
+        {
+            LogManager.getLogger().error("Unable to list custom structures", e);
+        }
+
+        Pattern pattern = Pattern.compile(".*assets/(\\w+)/structures/([\\w/]+)\\.nbt");
+        try
+        {
+            Path root;
+            try
+            {
+                // try zip file first
+                FileSystem fs = FileSystems.newFileSystem(MinecraftServer.class.getProtectionDomain().getCodeSource().getLocation().toURI(), null);
+                root = fs.getPath("/");
+            }
+            catch (Exception e)
+            {
+                // try folder
+                root = Paths.get(MinecraftServer.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            }
+            Files.find(root, Integer.MAX_VALUE,
+                    (path, attr) -> attr.isRegularFile() && pattern.matcher(path.toString().replace(File.separator, "/")).matches())
+            .forEach(path -> {
+                Matcher matcher = pattern.matcher(path.toString().replace(File.separator, "/"));
+                matcher.matches(); // == true
+                templates.add(matcher.group(1) + ":" + matcher.group(2));
+            });
+        }
+        catch (IOException | URISyntaxException e)
+        {
+            LogManager.getLogger().error("Unable to list built in structures", e);
+        }
+        
+        Collections.sort(templates);
+        
+        return templates;
+    }
+    
+    @Override
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, BlockPos targetPos)
+    {
+        if (args.length == 0)
+        {
+            return Collections.emptyList();
+        }
+        else if (args.length == 1)
+        {
+            return getListOfStringsMatchingLastWord(args, "load", "save", "list");
+        }
+        else if ("load".equals(args[0]) || "save".equals(args[0]))
+        {
+            if (args.length == 2)
+            {
+                return getListOfStringsMatchingLastWord(args, listStructures(server.worlds[0].getStructureTemplateManager()));
+            }
+            else if (args.length >= 3 && args.length <= 5)
+            {
+                return getTabCompletionCoordinate(args, 2, targetPos);
+            }
+            else if ("load".equals(args[0]))
+            {
+                if (args.length == 6)
+                {
+                    return getListOfStringsMatchingLastWord(args, "no_mirror", "mirror_left_right", "mirror_front_back");
+                }
+                else if (args.length == 7)
+                {
+                    return getListOfStringsMatchingLastWord(args, "rotate_0", "rotate_90", "rotate_180", "rotate_270");
+                }
+                else if (args.length == 8)
+                {
+                    return getListOfStringsMatchingLastWord(args, "true", "false");
+                }
+                else
+                {
+                    return Collections.emptyList();
+                }
+            }
+            else
+            {
+                if (args.length >= 6 && args.length <= 8)
+                {
+                    return getTabCompletionCoordinate(args, 5, targetPos);
+                }
+                else if (args.length == 9)
+                {
+                    return getListOfStringsMatchingLastWord(args, "true", "false");
+                }
+                else
+                {
+                    return Collections.emptyList();
+                }
+            }
+        }
+        else
+        {
+            return Collections.emptyList();
+        }
+    }
+
+}

--- a/carpetmodSrc/carpet/helpers/IPlayerSensitiveTileEntity.java
+++ b/carpetmodSrc/carpet/helpers/IPlayerSensitiveTileEntity.java
@@ -1,0 +1,9 @@
+package carpet.helpers;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.SPacketUpdateTileEntity;
+
+public interface IPlayerSensitiveTileEntity
+{
+    SPacketUpdateTileEntity getUpdatePacketPlayerSensitive(EntityPlayerMP player);
+}

--- a/patches/net/minecraft/command/ServerCommandManager.java.patch
+++ b/patches/net/minecraft/command/ServerCommandManager.java.patch
@@ -11,7 +11,7 @@
  public class ServerCommandManager extends CommandHandler implements ICommandListener
  {
      private final MinecraftServer field_184880_a;
-@@ -89,7 +93,31 @@
+@@ -89,7 +93,32 @@
          this.func_71560_a(new CommandLocate());
          this.func_71560_a(new CommandReload());
          this.func_71560_a(new CommandFunction());
@@ -33,6 +33,7 @@
 +        this.func_71560_a(new CommandPerimeter());
 +        this.func_71560_a(new CommandRNG());
 +        this.func_71560_a(new CommandTickingArea());
++        this.func_71560_a(new CommandStructure());
  
 +        this.func_71560_a(new CommandPlayer());
 +        /* end */

--- a/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -1,16 +1,17 @@
 --- ../src-base/minecraft/net/minecraft/entity/player/EntityPlayerMP.java
 +++ ../src-work/minecraft/net/minecraft/entity/player/EntityPlayerMP.java
-@@ -114,6 +114,9 @@
+@@ -114,6 +114,10 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
 +import carpet.helpers.EntityPlayerActionPack;
++import carpet.helpers.IPlayerSensitiveTileEntity;
 +import carpet.logging.logHelpers.DamageReporter;
 +
  public class EntityPlayerMP extends EntityPlayer implements IContainerListener
  {
      private static final Logger field_147102_bM = LogManager.getLogger();
-@@ -153,6 +156,9 @@
+@@ -153,6 +157,9 @@
      public int field_71138_i;
      public boolean field_71136_j;
  
@@ -20,7 +21,7 @@
      public EntityPlayerMP(MinecraftServer p_i45285_1_, WorldServer p_i45285_2_, GameProfile p_i45285_3_, PlayerInteractionManager p_i45285_4_)
      {
          super(p_i45285_2_, p_i45285_3_);
-@@ -188,6 +194,9 @@
+@@ -188,6 +195,9 @@
          {
              this.func_70107_b(this.field_70165_t, this.field_70163_u + 1.0D, this.field_70161_v);
          }
@@ -30,7 +31,7 @@
      }
  
      public void func_70037_a(NBTTagCompound p_70037_1_)
-@@ -313,6 +322,9 @@
+@@ -313,6 +323,9 @@
  
      public void func_70071_h_()
      {
@@ -40,7 +41,7 @@
          this.field_71134_c.func_73075_a();
          --this.field_147101_bU;
  
-@@ -605,6 +617,7 @@
+@@ -605,6 +618,7 @@
  
              if (!flag && this.field_147101_bU > 0 && p_70097_1_ != DamageSource.field_76380_i)
              {
@@ -48,7 +49,7 @@
                  return false;
              }
              else
-@@ -615,6 +628,7 @@
+@@ -615,6 +629,7 @@
  
                      if (entity instanceof EntityPlayer && !this.func_96122_a((EntityPlayer)entity))
                      {
@@ -56,7 +57,7 @@
                          return false;
                      }
  
-@@ -624,6 +638,7 @@
+@@ -624,6 +639,7 @@
  
                          if (entityarrow.field_70250_c instanceof EntityPlayer && !this.func_96122_a((EntityPlayer)entityarrow.field_70250_c))
                          {
@@ -64,3 +65,12 @@
                              return false;
                          }
                      }
+@@ -704,6 +720,8 @@
+         if (p_147097_1_ != null)
+         {
+             SPacketUpdateTileEntity spacketupdatetileentity = p_147097_1_.func_189518_D_();
++            if (p_147097_1_ instanceof IPlayerSensitiveTileEntity)
++                spacketupdatetileentity = ((IPlayerSensitiveTileEntity) p_147097_1_).getUpdatePacketPlayerSensitive(this);
+ 
+             if (spacketupdatetileentity != null)
+             {

--- a/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -1,12 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/network/NetHandlerPlayServer.java
 +++ ../src-work/minecraft/net/minecraft/network/NetHandlerPlayServer.java
-@@ -120,11 +120,15 @@
+@@ -120,11 +120,16 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
 +import carpet.CarpetServer;
 +import carpet.CarpetSettings;
 +import carpet.helpers.TickSpeed;
++import net.minecraft.world.gen.structure.template.Template;
 +
  public class NetHandlerPlayServer implements INetHandlerPlayServer, ITickable
  {
@@ -17,7 +18,7 @@
      public EntityPlayerMP field_147369_b;
      private int field_147368_e;
      private int field_147378_h;
-@@ -249,7 +253,7 @@
+@@ -249,7 +254,7 @@
          }
      }
  
@@ -26,7 +27,7 @@
      {
          this.field_184349_l = this.field_147369_b.field_70165_t;
          this.field_184350_m = this.field_147369_b.field_70163_u;
-@@ -287,6 +291,11 @@
+@@ -287,6 +292,11 @@
      {
          PacketThreadUtil.func_180031_a(p_147358_1_, this, this.field_147369_b.func_71121_q());
          this.field_147369_b.func_110430_a(p_147358_1_.func_149620_c(), p_147358_1_.func_192620_b(), p_147358_1_.func_149618_e(), p_147358_1_.func_149617_f());
@@ -38,7 +39,7 @@
      }
  
      private static boolean func_183006_b(CPacketPlayer p_183006_0_)
-@@ -490,6 +499,10 @@
+@@ -490,6 +500,10 @@
                          double d10 = this.field_147369_b.field_70159_w * this.field_147369_b.field_70159_w + this.field_147369_b.field_70181_x * this.field_147369_b.field_70181_x + this.field_147369_b.field_70179_y * this.field_147369_b.field_70179_y;
                          double d11 = d7 * d7 + d8 * d8 + d9 * d9;
  
@@ -49,7 +50,7 @@
                          if (this.field_147369_b.func_70608_bn())
                          {
                              if (d11 > 1.0D)
-@@ -508,7 +521,7 @@
+@@ -508,7 +522,7 @@
                                  i = 1;
                              }
  
@@ -58,7 +59,7 @@
                              {
                                  float f2 = this.field_147369_b.func_184613_cA() ? 300.0F : 100.0F;
  
-@@ -1200,7 +1213,15 @@
+@@ -1200,7 +1214,15 @@
                              }
                              else
                              {
@@ -75,7 +76,7 @@
                              }
                          }
  
-@@ -1732,13 +1753,14 @@
+@@ -1732,13 +1754,14 @@
                      String s8 = packetbuffer5.func_150789_c(32);
                      tileentitystructure.func_184405_a(TileEntityStructure.Mode.valueOf(s8));
                      tileentitystructure.func_184404_a(packetbuffer5.func_150789_c(64));
@@ -96,7 +97,25 @@
                      tileentitystructure.func_184409_c(new BlockPos(l2, i3, j));
                      String s2 = packetbuffer5.func_150789_c(32);
                      tileentitystructure.func_184411_a(Mirror.valueOf(s2));
-@@ -1816,5 +1838,9 @@
+@@ -1775,6 +1798,17 @@
+                         }
+                         else
+                         {
++                            boolean structureTooBig = false;
++                            Template template = field_147367_d.field_71305_c[0].func_184163_y().func_189942_b(field_147367_d, new ResourceLocation(s4));
++                            if (template != null)
++                            {
++                                BlockPos size = template.func_186259_a();
++                                if (size.func_177958_n() > sbl || size.func_177956_o() > sbl || size.func_177952_p() > sbl)
++                                    structureTooBig = true;
++                            }
++                            if (structureTooBig)
++                                field_147369_b.func_146105_b(new TextComponentString("Structure is too big for structure limit"), false);
++                            else
+                             this.field_147369_b.func_146105_b(new TextComponentTranslation("structure_block.load_prepare", new Object[] {s4}), false);
+                         }
+                     }
+@@ -1816,5 +1850,9 @@
                  field_147370_c.error("Couldn't pick item", (Throwable)exception);
              }
          }

--- a/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -75,7 +75,28 @@
                              }
                          }
  
-@@ -1816,5 +1837,9 @@
+@@ -1732,13 +1753,14 @@
+                     String s8 = packetbuffer5.func_150789_c(32);
+                     tileentitystructure.func_184405_a(TileEntityStructure.Mode.valueOf(s8));
+                     tileentitystructure.func_184404_a(packetbuffer5.func_150789_c(64));
+-                    int i2 = MathHelper.func_76125_a(packetbuffer5.readInt(), -32, 32);
+-                    int j2 = MathHelper.func_76125_a(packetbuffer5.readInt(), -32, 32);
+-                    int k2 = MathHelper.func_76125_a(packetbuffer5.readInt(), -32, 32);
++                    int sbl = CarpetSettings.structureBlockLimit;
++                    int i2 = MathHelper.func_76125_a(packetbuffer5.readInt(), -sbl, sbl);
++                    int j2 = MathHelper.func_76125_a(packetbuffer5.readInt(), -sbl, sbl);
++                    int k2 = MathHelper.func_76125_a(packetbuffer5.readInt(), -sbl, sbl);
+                     tileentitystructure.func_184414_b(new BlockPos(i2, j2, k2));
+-                    int l2 = MathHelper.func_76125_a(packetbuffer5.readInt(), 0, 32);
+-                    int i3 = MathHelper.func_76125_a(packetbuffer5.readInt(), 0, 32);
+-                    int j = MathHelper.func_76125_a(packetbuffer5.readInt(), 0, 32);
++                    int l2 = MathHelper.func_76125_a(packetbuffer5.readInt(), 0, sbl);
++                    int i3 = MathHelper.func_76125_a(packetbuffer5.readInt(), 0, sbl);
++                    int j = MathHelper.func_76125_a(packetbuffer5.readInt(), 0, sbl);
+                     tileentitystructure.func_184409_c(new BlockPos(l2, i3, j));
+                     String s2 = packetbuffer5.func_150789_c(32);
+                     tileentitystructure.func_184411_a(Mirror.valueOf(s2));
+@@ -1816,5 +1838,9 @@
                  field_147370_c.error("Couldn't pick item", (Throwable)exception);
              }
          }

--- a/patches/net/minecraft/server/management/PlayerChunkMapEntry.java.patch
+++ b/patches/net/minecraft/server/management/PlayerChunkMapEntry.java.patch
@@ -1,0 +1,40 @@
+--- ../src-base/minecraft/net/minecraft/server/management/PlayerChunkMapEntry.java
++++ ../src-work/minecraft/net/minecraft/server/management/PlayerChunkMapEntry.java
+@@ -19,6 +19,8 @@
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
++import carpet.helpers.IPlayerSensitiveTileEntity;
++
+ public class PlayerChunkMapEntry
+ {
+     private static final Logger field_187281_a = LogManager.getLogger();
+@@ -248,12 +250,28 @@
+     {
+         if (p_187273_1_ != null)
+         {
++            if (p_187273_1_ instanceof IPlayerSensitiveTileEntity)
++            {
++                if (field_187290_j)
++                {
++                    for (int i = 0; i < field_187283_c.size(); i++)
++                    {
++                        EntityPlayerMP player = field_187283_c.get(i);
++                        SPacketUpdateTileEntity packet = ((IPlayerSensitiveTileEntity) p_187273_1_).getUpdatePacketPlayerSensitive(player);
++                        if (packet != null)
++                            player.field_71135_a.func_147359_a(packet);
++                    }
++                }
++            }
++            else
++            {
+             SPacketUpdateTileEntity spacketupdatetileentity = p_187273_1_.func_189518_D_();
+ 
+             if (spacketupdatetileentity != null)
+             {
+                 this.func_187267_a(spacketupdatetileentity);
+             }
++            }
+         }
+     }
+ 

--- a/patches/net/minecraft/tileentity/TileEntityStructure.java.patch
+++ b/patches/net/minecraft/tileentity/TileEntityStructure.java.patch
@@ -1,0 +1,59 @@
+--- ../src-base/minecraft/net/minecraft/tileentity/TileEntityStructure.java
++++ ../src-work/minecraft/net/minecraft/tileentity/TileEntityStructure.java
+@@ -31,7 +31,13 @@
+ import net.minecraft.world.gen.structure.template.Template;
+ import net.minecraft.world.gen.structure.template.TemplateManager;
+ 
+-public class TileEntityStructure extends TileEntity
++import carpet.CarpetSettings;
++import carpet.carpetclient.CarpetClientServer;
++import carpet.helpers.IPlayerSensitiveTileEntity;
++import carpet.utils.PluginChannelTracker;
++import net.minecraft.entity.player.EntityPlayerMP;
++
++public class TileEntityStructure extends TileEntity implements IPlayerSensitiveTileEntity
+ {
+     private String field_184420_a = "";
+     private String field_184421_f = "";
+@@ -78,13 +84,14 @@
+         this.func_184404_a(p_145839_1_.func_74779_i("name"));
+         this.field_184421_f = p_145839_1_.func_74779_i("author");
+         this.field_184422_g = p_145839_1_.func_74779_i("metadata");
+-        int i = MathHelper.func_76125_a(p_145839_1_.func_74762_e("posX"), -32, 32);
+-        int j = MathHelper.func_76125_a(p_145839_1_.func_74762_e("posY"), -32, 32);
+-        int k = MathHelper.func_76125_a(p_145839_1_.func_74762_e("posZ"), -32, 32);
++        int sbl = CarpetSettings.structureBlockLimit;
++        int i = MathHelper.func_76125_a(p_145839_1_.func_74762_e("posX"), -sbl, sbl);
++        int j = MathHelper.func_76125_a(p_145839_1_.func_74762_e("posY"), -sbl, sbl);
++        int k = MathHelper.func_76125_a(p_145839_1_.func_74762_e("posZ"), -sbl, sbl);
+         this.field_184423_h = new BlockPos(i, j, k);
+-        int l = MathHelper.func_76125_a(p_145839_1_.func_74762_e("sizeX"), 0, 32);
+-        int i1 = MathHelper.func_76125_a(p_145839_1_.func_74762_e("sizeY"), 0, 32);
+-        int j1 = MathHelper.func_76125_a(p_145839_1_.func_74762_e("sizeZ"), 0, 32);
++        int l = MathHelper.func_76125_a(p_145839_1_.func_74762_e("sizeX"), 0, sbl);
++        int i1 = MathHelper.func_76125_a(p_145839_1_.func_74762_e("sizeY"), 0, sbl);
++        int j1 = MathHelper.func_76125_a(p_145839_1_.func_74762_e("sizeZ"), 0, sbl);
+         this.field_184424_i = new BlockPos(l, i1, j1);
+ 
+         try
+@@ -151,6 +158,20 @@
+     {
+         return new SPacketUpdateTileEntity(this.field_174879_c, 7, this.func_189517_E_());
+     }
++    
++    // Carpet: make sure the rendering isn't messed up for non-carpet-client clients when size is greater than vanilla limit
++    @Override
++    public SPacketUpdateTileEntity getUpdatePacketPlayerSensitive(EntityPlayerMP player)
++    {
++        NBTTagCompound updateTag = func_189517_E_();
++        if (!PluginChannelTracker.isRegistered(player, CarpetClientServer.CARPET_CHANNEL_NAME) && (field_184424_i.func_177958_n() > 32 || field_184424_i.func_177956_o() > 32 || field_184424_i.func_177952_p() > 32))
++        {
++            updateTag.func_74768_a("sizeX", 0);
++            updateTag.func_74768_a("sizeY", 0);
++            updateTag.func_74768_a("sizeZ", 0);
++        }
++        return new SPacketUpdateTileEntity(field_174879_c, 7, updateTag);
++    }
+ 
+     public NBTTagCompound func_189517_E_()
+     {

--- a/patches/net/minecraft/world/gen/structure/template/TemplateManager.java.patch
+++ b/patches/net/minecraft/world/gen/structure/template/TemplateManager.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/structure/template/TemplateManager.java
++++ ../src-work/minecraft/net/minecraft/world/gen/structure/template/TemplateManager.java
+@@ -20,7 +20,7 @@
+ public class TemplateManager
+ {
+     private final Map<String, Template> field_186240_a = Maps.<String, Template>newHashMap();
+-    private final String field_186241_b;
++    public final String field_186241_b; // CM: changed to public
+     private final DataFixer field_191154_c;
+ 
+     public TemplateManager(String p_i47239_1_, DataFixer p_i47239_2_)


### PR DESCRIPTION
This PR allows players to increase the structure block 32 block limit.
This have made this work with vanilla clients, but due to some hard coded constants in the code it is not possible to always draw the bounding boxes properly with a vanilla client. Therefore, if the bounding box is too big for a vanilla client to render, the carpet server will lie to the vanilla client and say there is no bounding box.
I have also created a PR to carpet client to implement the "proper" fix too, and this PR should also handle these carpet clients properly.

This also implements the /structure command, which does the equivalent of a structure block, without the need for an actual block or GUI. The advantage of this is that you can start further automating creation of structure files without any need for a player.