### PR TITLE
Recipe desync fix

### DIFF
--- a/patches/net/minecraft/item/crafting/CraftingManager.java.patch
+++ b/patches/net/minecraft/item/crafting/CraftingManager.java.patch
@@ -1,26 +1,82 @@
 --- ../src-base/minecraft/net/minecraft/item/crafting/CraftingManager.java
 +++ ../src-work/minecraft/net/minecraft/item/crafting/CraftingManager.java
-@@ -32,6 +32,8 @@
+@@ -32,16 +32,30 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
 +import carpet.helpers.FireworksCraftingRecipes;
++import com.google.common.collect.BiMap;
++import com.google.common.collect.HashBiMap;
 +
  public class CraftingManager
  {
      private static final Logger field_192422_a = LogManager.getLogger();
-@@ -42,6 +44,14 @@
+     private static int field_193381_c;
+     public static final RegistryNamespaced<ResourceLocation, IRecipe> field_193380_a = new RegistryNamespaced<ResourceLocation, IRecipe>();
++    public static final BiMap<Integer, Integer> CARPET_TO_VANILLA = HashBiMap.create();
++    private static int nextVanillaId;
+ 
+     public static boolean func_193377_a()
      {
          try
          {
 +        	// Added rockets to the list of crafting recipes CARPET-XCOM
 +            // will add later if found a way to hide popups for vanilla clients
 +        	FireworksCraftingRecipes.createRockets();
-+        	func_193379_a("rocket1", FireworksCraftingRecipes.rocketOne);
-+        	func_193379_a("rocket2", FireworksCraftingRecipes.rocketTwo);
-+        	func_193379_a("rocket3", FireworksCraftingRecipes.rocketThree);
++        	register(new ResourceLocation("rocket1"), FireworksCraftingRecipes.rocketOne, false);
++        	register(new ResourceLocation("rocket2"), FireworksCraftingRecipes.rocketTwo, false);
++        	register(new ResourceLocation("rocket3"), FireworksCraftingRecipes.rocketThree, false);
 +        	// End
 +        	
              func_193379_a("armordye", new RecipesArmorDyes());
              func_193379_a("bookcloning", new RecipeBookCloning());
              func_193379_a("mapcloning", new RecipesMapCloning());
+@@ -177,16 +191,24 @@
+     {
+         func_193372_a(new ResourceLocation(p_193379_0_), p_193379_1_);
+     }
+-
++    
+     public static void func_193372_a(ResourceLocation p_193372_0_, IRecipe p_193372_1_)
+     {
+-        if (field_193380_a.func_148741_d(p_193372_0_))
++        register(p_193372_0_, p_193372_1_, true);
++    }
++
++    public static void register(ResourceLocation name, IRecipe recipe, boolean vanilla)
++    {
++        if (field_193380_a.func_148741_d(name))
+         {
+-            throw new IllegalStateException("Duplicate recipe ignored with ID " + p_193372_0_);
++            throw new IllegalStateException("Duplicate recipe ignored with ID " + name);
+         }
+         else
+         {
+-            field_193380_a.func_177775_a(field_193381_c++, p_193372_0_, p_193372_1_);
++            int id = field_193381_c++;
++            field_193380_a.func_177775_a(id, name, recipe);
++            if (vanilla)
++                CARPET_TO_VANILLA.put(id, nextVanillaId++);
+         }
+     }
+ 
+@@ -253,4 +275,19 @@
+     {
+         return field_193380_a.func_148754_a(p_193374_0_);
+     }
++    
++    public static int getVanillaId(IRecipe recipe)
++    {
++        return CARPET_TO_VANILLA.get(func_193375_a(recipe));
++    }
++    
++    public static boolean isVanilla(IRecipe recipe)
++    {
++        return CARPET_TO_VANILLA.containsKey(func_193375_a(recipe));
++    }
++    
++    public static IRecipe getByVanillaId(int id)
++    {
++        return func_193374_a(CARPET_TO_VANILLA.inverse().get(id));
++    }
+ }

--- a/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -93,7 +93,19 @@
                              }
                          }
  
-@@ -1816,5 +1846,9 @@
+@@ -1384,6 +1414,11 @@
+             int i = (int)(this.func_147363_d() - this.field_147379_i);
+             this.field_147369_b.field_71138_i = (this.field_147369_b.field_71138_i * 3 + i) / 4;
+         }
++        else if (p_147353_1_.func_149460_c() == CarpetServer.VANILLA_CHECK_PING_ID)
++        {
++            PacketThreadUtil.func_180031_a(p_147353_1_, this, this.field_147369_b.func_71121_q());
++            CarpetServer.receiveVanillaCheck(field_147369_b);
++        }
+     }
+ 
+     private long func_147363_d()
+@@ -1816,5 +1851,9 @@
                  field_147370_c.error("Couldn't pick item", (Throwable)exception);
              }
          }

--- a/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -1,12 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/network/NetHandlerPlayServer.java
 +++ ../src-work/minecraft/net/minecraft/network/NetHandlerPlayServer.java
-@@ -120,11 +120,15 @@
+@@ -120,11 +120,19 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
 +import carpet.CarpetServer;
 +import carpet.CarpetSettings;
++import carpet.carpetclient.CarpetClientServer;
 +import carpet.helpers.TickSpeed;
++import carpet.utils.PluginChannelTracker;
++import net.minecraft.item.crafting.CraftingManager;
++import net.minecraft.item.crafting.IRecipe;
 +
  public class NetHandlerPlayServer implements INetHandlerPlayServer, ITickable
  {
@@ -17,7 +21,7 @@
      public EntityPlayerMP field_147369_b;
      private int field_147368_e;
      private int field_147378_h;
-@@ -249,7 +253,7 @@
+@@ -249,7 +257,7 @@
          }
      }
  
@@ -26,7 +30,7 @@
      {
          this.field_184349_l = this.field_147369_b.field_70165_t;
          this.field_184350_m = this.field_147369_b.field_70163_u;
-@@ -287,6 +291,11 @@
+@@ -287,6 +295,11 @@
      {
          PacketThreadUtil.func_180031_a(p_147358_1_, this, this.field_147369_b.func_71121_q());
          this.field_147369_b.func_110430_a(p_147358_1_.func_149620_c(), p_147358_1_.func_192620_b(), p_147358_1_.func_149618_e(), p_147358_1_.func_149617_f());
@@ -38,7 +42,21 @@
      }
  
      private static boolean func_183006_b(CPacketPlayer p_183006_0_)
-@@ -490,6 +499,10 @@
+@@ -412,7 +425,12 @@
+ 
+         if (p_191984_1_.func_194156_a() == CPacketRecipeInfo.Purpose.SHOWN)
+         {
+-            this.field_147369_b.func_192037_E().func_194074_f(p_191984_1_.func_193648_b());
++            IRecipe recipe;
++            if (PluginChannelTracker.isRegistered(field_147369_b, CarpetClientServer.CARPET_CHANNEL_NAME))
++                recipe = CraftingManager.func_193374_a(p_191984_1_.recipeId);
++            else
++                recipe = CraftingManager.getByVanillaId(p_191984_1_.recipeId);
++            this.field_147369_b.func_192037_E().func_194074_f(recipe);
+         }
+         else if (p_191984_1_.func_194156_a() == CPacketRecipeInfo.Purpose.SETTINGS)
+         {
+@@ -490,6 +508,10 @@
                          double d10 = this.field_147369_b.field_70159_w * this.field_147369_b.field_70159_w + this.field_147369_b.field_70181_x * this.field_147369_b.field_70181_x + this.field_147369_b.field_70179_y * this.field_147369_b.field_70179_y;
                          double d11 = d7 * d7 + d8 * d8 + d9 * d9;
  
@@ -49,7 +67,7 @@
                          if (this.field_147369_b.func_70608_bn())
                          {
                              if (d11 > 1.0D)
-@@ -508,7 +521,7 @@
+@@ -508,7 +530,7 @@
                                  i = 1;
                              }
  
@@ -58,7 +76,7 @@
                              {
                                  float f2 = this.field_147369_b.func_184613_cA() ? 300.0F : 100.0F;
  
-@@ -1200,7 +1213,15 @@
+@@ -1200,7 +1222,15 @@
                              }
                              else
                              {
@@ -75,7 +93,7 @@
                              }
                          }
  
-@@ -1816,5 +1837,9 @@
+@@ -1816,5 +1846,9 @@
                  field_147370_c.error("Couldn't pick item", (Throwable)exception);
              }
          }

--- a/patches/net/minecraft/network/play/client/CPacketRecipeInfo.java.patch
+++ b/patches/net/minecraft/network/play/client/CPacketRecipeInfo.java.patch
@@ -1,0 +1,19 @@
+--- ../src-base/minecraft/net/minecraft/network/play/client/CPacketRecipeInfo.java
++++ ../src-work/minecraft/net/minecraft/network/play/client/CPacketRecipeInfo.java
+@@ -13,6 +13,7 @@
+     private IRecipe field_193649_d;
+     private boolean field_192631_e;
+     private boolean field_192632_f;
++    public int recipeId;
+ 
+     public CPacketRecipeInfo()
+     {
+@@ -30,7 +31,7 @@
+ 
+         if (this.field_194157_a == CPacketRecipeInfo.Purpose.SHOWN)
+         {
+-            this.field_193649_d = CraftingManager.func_193374_a(p_148837_1_.readInt());
++            this.recipeId = p_148837_1_.readInt();
+         }
+         else if (this.field_194157_a == CPacketRecipeInfo.Purpose.SETTINGS)
+         {

--- a/patches/net/minecraft/network/play/server/SPacketRecipeBook.java.patch
+++ b/patches/net/minecraft/network/play/server/SPacketRecipeBook.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/network/play/server/SPacketRecipeBook.java
 +++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketRecipeBook.java
-@@ -16,18 +16,20 @@
+@@ -9,6 +9,8 @@
+ import net.minecraft.network.PacketBuffer;
+ import net.minecraft.network.play.INetHandlerPlayClient;
+ 
++import java.util.stream.Collectors;
++
+ public class SPacketRecipeBook implements Packet<INetHandlerPlayClient>
+ {
+     private SPacketRecipeBook.State field_193646_a;
+@@ -16,18 +18,28 @@
      private List<IRecipe> field_193647_c;
      private boolean field_192598_c;
      private boolean field_192599_d;
@@ -18,15 +27,23 @@
 -        this.field_193647_c = p_i47597_3_;
 -        this.field_192598_c = p_i47597_4_;
 +        this.field_193646_a = stateIn;
++        if (vanilla)
++        {
++            this.field_192596_a = recipesIn.stream().filter(CraftingManager::isVanilla).collect(Collectors.toList());
++            this.field_193647_c = displayedRecipesIn.stream().filter(CraftingManager::isVanilla).collect(Collectors.toList());
++        }
++        else
++        {
 +        this.field_192596_a = recipesIn;
 +        this.field_193647_c = displayedRecipesIn;
++        }
 +        this.field_192598_c = isGuiOpen;
          this.field_192599_d = p_i47597_5_;
 +        this.vanilla = vanilla;
      }
  
      public void func_148833_a(INetHandlerPlayClient p_148833_1_)
-@@ -69,7 +71,7 @@
+@@ -69,7 +81,7 @@
  
          for (IRecipe irecipe : this.field_192596_a)
          {
@@ -35,7 +52,7 @@
          }
  
          if (this.field_193646_a == SPacketRecipeBook.State.INIT)
-@@ -78,7 +80,7 @@
+@@ -78,7 +90,7 @@
  
              for (IRecipe irecipe1 : this.field_193647_c)
              {

--- a/patches/net/minecraft/network/play/server/SPacketRecipeBook.java.patch
+++ b/patches/net/minecraft/network/play/server/SPacketRecipeBook.java.patch
@@ -1,0 +1,46 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketRecipeBook.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketRecipeBook.java
+@@ -16,18 +16,20 @@
+     private List<IRecipe> field_193647_c;
+     private boolean field_192598_c;
+     private boolean field_192599_d;
++    private boolean vanilla;
+ 
+     public SPacketRecipeBook()
+     {
+     }
+ 
+-    public SPacketRecipeBook(SPacketRecipeBook.State p_i47597_1_, List<IRecipe> p_i47597_2_, List<IRecipe> p_i47597_3_, boolean p_i47597_4_, boolean p_i47597_5_)
++    public SPacketRecipeBook(SPacketRecipeBook.State stateIn, List<IRecipe> recipesIn, List<IRecipe> displayedRecipesIn, boolean isGuiOpen, boolean p_i47597_5_, boolean vanilla)
+     {
+-        this.field_193646_a = p_i47597_1_;
+-        this.field_192596_a = p_i47597_2_;
+-        this.field_193647_c = p_i47597_3_;
+-        this.field_192598_c = p_i47597_4_;
++        this.field_193646_a = stateIn;
++        this.field_192596_a = recipesIn;
++        this.field_193647_c = displayedRecipesIn;
++        this.field_192598_c = isGuiOpen;
+         this.field_192599_d = p_i47597_5_;
++        this.vanilla = vanilla;
+     }
+ 
+     public void func_148833_a(INetHandlerPlayClient p_148833_1_)
+@@ -69,7 +71,7 @@
+ 
+         for (IRecipe irecipe : this.field_192596_a)
+         {
+-            p_148840_1_.func_150787_b(CraftingManager.func_193375_a(irecipe));
++            p_148840_1_.func_150787_b(vanilla ? CraftingManager.getVanillaId(irecipe) : CraftingManager.func_193375_a(irecipe));
+         }
+ 
+         if (this.field_193646_a == SPacketRecipeBook.State.INIT)
+@@ -78,7 +80,7 @@
+ 
+             for (IRecipe irecipe1 : this.field_193647_c)
+             {
+-                p_148840_1_.func_150787_b(CraftingManager.func_193375_a(irecipe1));
++                p_148840_1_.func_150787_b(vanilla ? CraftingManager.getVanillaId(irecipe1) : CraftingManager.func_193375_a(irecipe1));
+             }
+         }
+     }

--- a/patches/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/net/minecraft/server/management/PlayerList.java.patch
@@ -21,6 +21,15 @@
          nethandlerplayserver.func_147359_a(new SPacketJoinGame(p_72355_2_.func_145782_y(), p_72355_2_.field_71134_c.func_73081_b(), worldinfo.func_76093_s(), worldserver.field_73011_w.func_186058_p().func_186068_a(), worldserver.func_175659_aa(), this.func_72352_l(), worldinfo.func_76067_t(), worldserver.func_82736_K().func_82766_b("reducedDebugInfo")));
          nethandlerplayserver.func_147359_a(new SPacketCustomPayload("MC|Brand", (new PacketBuffer(Unpooled.buffer())).func_180714_a(this.func_72365_p().getServerModName())));
          nethandlerplayserver.func_147359_a(new SPacketServerDifficulty(worldinfo.func_176130_y(), worldinfo.func_176123_z()));
+@@ -133,7 +138,7 @@
+         nethandlerplayserver.func_147359_a(new SPacketHeldItemChange(p_72355_2_.field_71071_by.field_70461_c));
+         this.func_187243_f(p_72355_2_);
+         p_72355_2_.func_147099_x().func_150877_d();
+-        p_72355_2_.func_192037_E().func_192826_c(p_72355_2_);
++        //playerIn.getRecipeBook().init(playerIn); // CM: this depends on whether the client is vanilla, wait until we know
+         this.func_96456_a((ServerScoreboard)worldserver.func_96441_U(), p_72355_2_);
+         this.field_72400_f.func_147132_au();
+         TextComponentTranslation textcomponenttranslation;
 @@ -343,6 +348,8 @@
  
          worldserver.func_72838_d(p_72377_1_);

--- a/patches/net/minecraft/stats/RecipeBookServer.java.patch
+++ b/patches/net/minecraft/stats/RecipeBookServer.java.patch
@@ -1,0 +1,29 @@
+--- ../src-base/minecraft/net/minecraft/stats/RecipeBookServer.java
++++ ../src-work/minecraft/net/minecraft/stats/RecipeBookServer.java
+@@ -15,6 +15,9 @@
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
++import carpet.carpetclient.CarpetClientServer;
++import carpet.utils.PluginChannelTracker;
++
+ public class RecipeBookServer extends RecipeBook
+ {
+     private static final Logger field_192828_d = LogManager.getLogger();
+@@ -55,7 +58,7 @@
+ 
+     private void func_194081_a(SPacketRecipeBook.State p_194081_1_, EntityPlayerMP p_194081_2_, List<IRecipe> p_194081_3_)
+     {
+-        p_194081_2_.field_71135_a.func_147359_a(new SPacketRecipeBook(p_194081_1_, p_194081_3_, Collections.emptyList(), this.field_192818_b, this.field_192819_c));
++        p_194081_2_.field_71135_a.func_147359_a(new SPacketRecipeBook(p_194081_1_, p_194081_3_, Collections.emptyList(), this.field_192818_b, this.field_192819_c, !PluginChannelTracker.isRegistered(p_194081_2_, CarpetClientServer.CARPET_CHANNEL_NAME)));
+     }
+ 
+     public NBTTagCompound func_192824_e()
+@@ -147,6 +150,6 @@
+ 
+     public void func_192826_c(EntityPlayerMP p_192826_1_)
+     {
+-        p_192826_1_.field_71135_a.func_147359_a(new SPacketRecipeBook(SPacketRecipeBook.State.INIT, this.func_194079_d(), this.func_194080_e(), this.field_192818_b, this.field_192819_c));
++        p_192826_1_.field_71135_a.func_147359_a(new SPacketRecipeBook(SPacketRecipeBook.State.INIT, this.func_194079_d(), this.func_194080_e(), this.field_192818_b, this.field_192819_c, !PluginChannelTracker.isRegistered(p_192826_1_, CarpetClientServer.CARPET_CHANNEL_NAME)));
+     }
+ }


### PR DESCRIPTION
The recipe desync bug in carpet is due to the firework rocket recipes being added. Each recipe has an ID related to the order they were added, and adding 3 firework rocket recipes at the start shifts the IDs of all subsequent recipes by 3. The recipe ID is used to communicate recipes with the client with the recipe books.
Since carpet client makes the same change on the client side, this bug does not affect clients with carpet client installed. However, for vanilla clients it will show the wrong recipes unlocked. Of course, if all recipes have been unlocked this bug also isn't noticable, which is perhaps why this hasn't been noticed before.
As a side note, a similar effect can be seen when logging in to a vanilla server with carpet client, for which I will make a separate fix on carpet client. Additionally, when connecting to a 1.12.1 server with carpet client (using my connect to 1.12.x mod), it causes an additional desync, since the server is responsible for placing the recipe in 1.12.1. This also needs a fix on carpet client.

Since these firework rocket recipes have already been implemented this way, and there are people using the older carpet client versions, all bets are off for a simple clean fix on the carpet server. So my fix is slightly more dirty but hopefully acceptable.

### The fix
First, we build a mapping between vanilla recipe IDs and carpet recipe IDs. Then, whenever a recipe ID is sent or received, carpet will now check whether the client has carpet client installed, and if not, map the recipe ID to the vanilla mapping before sending.
There is one tiny catch: when the recipes are first sent to the client, that is before the LiteLoader REGISTER packet has been received on the server, so we can't know at that point whether the client is vanilla or not. So I've delayed the call to send the recipes to the client until we know whether the client is vanilla.