### PR TITLE
Fix #47 - Large structures fix

### DIFF
--- a/carpetmodSrc/carpet/carpetclient/CarpetClientMessageHandler.java
+++ b/carpetmodSrc/carpet/carpetclient/CarpetClientMessageHandler.java
@@ -13,139 +13,139 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.PacketBuffer;
 
 public class CarpetClientMessageHandler {
-    // Main packet data names
-    public static final int GUI_ALL_DATA = 0;
-    public static final int RULE_REQUEST = 1;
-    public static final int VILLAGE_MARKERS = 2;
-    public static final int BOUNDINGBOX_MARKERS = 3;
-    public static final int TICKRATE_CHANGES = 4;
-    public static final int LARGE_VILLAGE_MARKERS_START = 5;
-    public static final int LARGE_VILLAGE_MARKERS = 6;
-    public static final int LARGE_BOUNDINGBOX_MARKERS_START = 7;
-    public static final int LARGE_BOUNDINGBOX_MARKERS = 8;
+	// Main packet data names
+	public static final int GUI_ALL_DATA = 0;
+	public static final int RULE_REQUEST = 1;
+	public static final int VILLAGE_MARKERS = 2;
+	public static final int BOUNDINGBOX_MARKERS = 3;
+	public static final int TICKRATE_CHANGES = 4;
+	public static final int LARGE_VILLAGE_MARKERS_START = 5;
+	public static final int LARGE_VILLAGE_MARKERS = 6;
+	public static final int LARGE_BOUNDINGBOX_MARKERS_START = 7;
+	public static final int LARGE_BOUNDINGBOX_MARKERS = 8;
 
-    public static void handler(EntityPlayerMP sender, PacketBuffer data) {
-        int type = data.readInt();
+	public static void handler(EntityPlayerMP sender, PacketBuffer data) {
+		int type = data.readInt();
 
-        if (GUI_ALL_DATA == type) {
-            sendAllGUIOptions();
-        } else if (RULE_REQUEST == type) {
-            ruleRequest(sender, data);
-        } else if (VILLAGE_MARKERS == type) {
-            registerVillagerMarkers(sender, data);
-        } else if (BOUNDINGBOX_MARKERS == type) {
-            boundingboxRequest(sender, data);
-        }
-    }
+		if (GUI_ALL_DATA == type) {
+			sendAllGUIOptions();
+		} else if (RULE_REQUEST == type) {
+			ruleRequest(sender, data);
+		} else if (VILLAGE_MARKERS == type) {
+			registerVillagerMarkers(sender, data);
+		} else if (BOUNDINGBOX_MARKERS == type) {
+			boundingboxRequest(sender, data);
+		}
+	}
 
-    private static void registerVillagerMarkers(EntityPlayerMP sender, PacketBuffer data) {
-        CarpetClientMarkers.registerVillagerMarkers(sender, data);
-    }
+	private static void registerVillagerMarkers(EntityPlayerMP sender, PacketBuffer data) {
+		CarpetClientMarkers.registerVillagerMarkers(sender, data);
+	}
 
-    private static void boundingboxRequest(EntityPlayerMP sender, PacketBuffer data) {
-        CarpetClientMarkers.updateClientBoundingBoxMarkers(sender, data);
-    }
+	private static void boundingboxRequest(EntityPlayerMP sender, PacketBuffer data) {
+		CarpetClientMarkers.updateClientBoundingBoxMarkers(sender, data);
+	}
 
-    private static void ruleRequest(EntityPlayerMP sender, PacketBuffer data) {
-        CarpetClientRuleChanger.ruleChanger(sender, data);
-    }
+	private static void ruleRequest(EntityPlayerMP sender, PacketBuffer data) {
+		CarpetClientRuleChanger.ruleChanger(sender, data);
+	}
 
-    public static void sendAllGUIOptions() {
-        PacketBuffer data = new PacketBuffer(Unpooled.buffer());
-        data.writeInt(GUI_ALL_DATA);
+	public static void sendAllGUIOptions() {
+		PacketBuffer data = new PacketBuffer(Unpooled.buffer());
+		data.writeInt(GUI_ALL_DATA);
 
-        ArrayList<CarpetSettingEntry> list = CarpetSettings.getAllCarpetSettings();
+		ArrayList<CarpetSettingEntry> list = CarpetSettings.getAllCarpetSettings();
 
-        data.writeString(CarpetSettings.carpetVersion);
-        data.writeFloat(TickSpeed.tickrate);
-        data.writeInt(list.size());
-        for (CarpetSettingEntry cse : list) {
-            String rule = cse.getName();
-            String current = cse.getStringValue();
-            String[] options = cse.getOptions();
-            String def = cse.getDefault();
-            boolean isfloat = cse.getIsFloat();
+		data.writeString(CarpetSettings.carpetVersion);
+		data.writeFloat(TickSpeed.tickrate);
+		data.writeInt(list.size());
+		for (CarpetSettingEntry cse : list) {
+			String rule = cse.getName();
+			String current = cse.getStringValue();
+			String[] options = cse.getOptions();
+			String def = cse.getDefault();
+			boolean isfloat = cse.getIsFloat();
 
-            data.writeString(rule);
-            data.writeString(current);
-            data.writeString(def);
-            data.writeBoolean(isfloat);
-            // data.writeInt(options.length);
-            // for (String o : options) {
-            // data.writeString(o);
-            // }
-        }
+			data.writeString(rule);
+			data.writeString(current);
+			data.writeString(def);
+			data.writeBoolean(isfloat);
+			// data.writeInt(options.length);
+			// for (String o : options) {
+			// data.writeString(o);
+			// }
+		}
 
-        CarpetClientServer.sender(data);
-    }
+		CarpetClientServer.sender(data);
+	}
 
-    public static void sendNBTVillageData(EntityPlayerMP sender, NBTTagCompound compound) {
-        PacketBuffer data = new PacketBuffer(Unpooled.buffer());
-        data.writeInt(CarpetClientMessageHandler.VILLAGE_MARKERS);
+	public static void sendNBTVillageData(EntityPlayerMP sender, NBTTagCompound compound) {
+		PacketBuffer data = new PacketBuffer(Unpooled.buffer());
+		data.writeInt(CarpetClientMessageHandler.VILLAGE_MARKERS);
 
-        data.writeCompoundTag(compound);
+		data.writeCompoundTag(compound);
 
-        if (!CarpetClientServer.sender(data, sender)) {
-            // Payload was too large, try large packets for newer CC versions
-            NBTTagList villages = compound.getTagList("Villages", 10);
-            
-            data = new PacketBuffer(Unpooled.buffer());
-            data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS_START);
-            data.writeVarInt(villages.tagCount());
-            CarpetClientServer.sender(data, sender);
-            
-            for (int i = 0; i < villages.tagCount(); i += 256) {
-                data = new PacketBuffer(Unpooled.buffer());
-                data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS);
-                data.writeByte(Math.min(villages.tagCount() - i - 1, 255));
-                for (int j = i; j < villages.tagCount() && j < i + 256; j++) {
-                    data.writeCompoundTag(villages.getCompoundTagAt(j));
-                }
-                CarpetClientServer.sender(data, sender);
-            }
-        }
-    }
+		if (!CarpetClientServer.sender(data, sender)) {
+		    // Payload was too large, try large packets for newer CC versions
+		    NBTTagList villages = compound.getTagList("Villages", 10);
+		    
+		    data = new PacketBuffer(Unpooled.buffer());
+		    data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS_START);
+		    data.writeVarInt(villages.tagCount());
+		    CarpetClientServer.sender(data, sender);
+		    
+		    for (int i = 0; i < villages.tagCount(); i += 256) {
+		        data = new PacketBuffer(Unpooled.buffer());
+		        data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS);
+		        data.writeByte(Math.min(villages.tagCount() - i - 1, 255));
+		        for (int j = i; j < villages.tagCount() && j < i + 256; j++) {
+		            data.writeCompoundTag(villages.getCompoundTagAt(j));
+		        }
+		        CarpetClientServer.sender(data, sender);
+		    }
+		}
+	}
 
-    public static void sendNBTBoundingboxData(EntityPlayerMP sender, NBTTagCompound compound) {
-        PacketBuffer data = new PacketBuffer(Unpooled.buffer());
-        data.writeInt(CarpetClientMessageHandler.BOUNDINGBOX_MARKERS);
+	public static void sendNBTBoundingboxData(EntityPlayerMP sender, NBTTagCompound compound) {
+		PacketBuffer data = new PacketBuffer(Unpooled.buffer());
+		data.writeInt(CarpetClientMessageHandler.BOUNDINGBOX_MARKERS);
 
-        data.writeCompoundTag(compound);
+		data.writeCompoundTag(compound);
 
-        if (!CarpetClientServer.sender(data, sender)) {
-            // Payload was too large, try large packets for newer CC versions
-            NBTTagList boxes = compound.getTagList("Boxes", 9);
-            compound.removeTag("Boxes");
-            List<NBTTagCompound> allBoxes = new ArrayList<>();
-            for (int i = 0; i < boxes.tagCount(); i++) {
-                NBTTagList list = (NBTTagList) boxes.get(i);
-                for (int j = 0; j < list.tagCount(); j++) {
-                    allBoxes.add(list.getCompoundTagAt(j));
-                }
-            }
-            
-            data = new PacketBuffer(Unpooled.buffer());
-            data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS_START);
-            data.writeCompoundTag(compound);
-            data.writeVarInt(allBoxes.size());
-            CarpetClientServer.sender(data, sender);
-            
-            for (int i = 0; i < allBoxes.size(); i += 256) {
-                data = new PacketBuffer(Unpooled.buffer());
-                data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS);
-                data.writeByte(Math.min(allBoxes.size() - i - 1, 255));
-                for (int j = i; j < allBoxes.size() && j < i + 256; j++)
-                    data.writeCompoundTag(allBoxes.get(j));
-                CarpetClientServer.sender(data, sender);
-            }
-        }
-    }
+		if (!CarpetClientServer.sender(data, sender)) {
+		    // Payload was too large, try large packets for newer CC versions
+		    NBTTagList boxes = compound.getTagList("Boxes", 9);
+		    compound.removeTag("Boxes");
+		    List<NBTTagCompound> allBoxes = new ArrayList<>();
+		    for (int i = 0; i < boxes.tagCount(); i++) {
+		        NBTTagList list = (NBTTagList) boxes.get(i);
+		        for (int j = 0; j < list.tagCount(); j++) {
+		            allBoxes.add(list.getCompoundTagAt(j));
+		        }
+		    }
+		    
+		    data = new PacketBuffer(Unpooled.buffer());
+		    data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS_START);
+		    data.writeCompoundTag(compound);
+		    data.writeVarInt(allBoxes.size());
+		    CarpetClientServer.sender(data, sender);
+		    
+		    for (int i = 0; i < allBoxes.size(); i += 256) {
+		        data = new PacketBuffer(Unpooled.buffer());
+		        data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS);
+		        data.writeByte(Math.min(allBoxes.size() - i - 1, 255));
+		        for (int j = i; j < allBoxes.size() && j < i + 256; j++)
+		            data.writeCompoundTag(allBoxes.get(j));
+		        CarpetClientServer.sender(data, sender);
+		    }
+		}
+	}
 
-    public static void sendTickRateChanges() {
-        PacketBuffer data = new PacketBuffer(Unpooled.buffer());
-        data.writeInt(CarpetClientMessageHandler.TICKRATE_CHANGES);
-        data.writeFloat(TickSpeed.tickrate);
+	public static void sendTickRateChanges() {
+		PacketBuffer data = new PacketBuffer(Unpooled.buffer());
+		data.writeInt(CarpetClientMessageHandler.TICKRATE_CHANGES);
+		data.writeFloat(TickSpeed.tickrate);
 
-        CarpetClientServer.sender(data);
-    }
+		CarpetClientServer.sender(data);
+	}
 }

--- a/carpetmodSrc/carpet/carpetclient/CarpetClientMessageHandler.java
+++ b/carpetmodSrc/carpet/carpetclient/CarpetClientMessageHandler.java
@@ -1,14 +1,16 @@
 package carpet.carpetclient;
 
 import java.util.ArrayList;
+import java.util.List;
 
-import io.netty.buffer.Unpooled;
-import net.minecraft.entity.player.EntityPlayerMP;
 import carpet.CarpetSettings;
 import carpet.CarpetSettings.CarpetSettingEntry;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.network.PacketBuffer;
 import carpet.helpers.TickSpeed;
+import io.netty.buffer.Unpooled;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.PacketBuffer;
 
 public class CarpetClientMessageHandler {
 	// Main packet data names
@@ -17,6 +19,10 @@ public class CarpetClientMessageHandler {
 	public static final int VILLAGE_MARKERS = 2;
 	public static final int BOUNDINGBOX_MARKERS = 3;
 	public static final int TICKRATE_CHANGES = 4;
+	public static final int LARGE_VILLAGE_MARKERS_START = 5;
+	public static final int LARGE_VILLAGE_MARKERS = 6;
+	public static final int LARGE_BOUNDINGBOX_MARKERS_START = 7;
+	public static final int LARGE_BOUNDINGBOX_MARKERS = 8;
 
 	public static void handler(EntityPlayerMP sender, PacketBuffer data) {
 		int type = data.readInt();
@@ -79,7 +85,25 @@ public class CarpetClientMessageHandler {
 
 		data.writeCompoundTag(compound);
 
-		CarpetClientServer.sender(data, sender);
+		if (!CarpetClientServer.sender(data, sender)) {
+		    // Payload was too large, try large packets for newer CC versions
+		    NBTTagList villages = compound.getTagList("Villages", 10);
+		    
+		    data = new PacketBuffer(Unpooled.buffer());
+		    data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS_START);
+		    data.writeVarInt(villages.tagCount());
+		    CarpetClientServer.sender(data, sender);
+		    
+		    for (int i = 0; i < villages.tagCount(); i++) {
+		        NBTTagCompound tag = new NBTTagCompound();
+		        tag.setTag("Village", villages.getCompoundTagAt(i));
+		        
+		        data = new PacketBuffer(Unpooled.buffer());
+		        data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS);
+		        data.writeCompoundTag(tag);
+		        CarpetClientServer.sender(data, sender);
+		    }
+		}
 	}
 
 	public static void sendNBTBoundingboxData(EntityPlayerMP sender, NBTTagCompound compound) {
@@ -88,7 +112,31 @@ public class CarpetClientMessageHandler {
 
 		data.writeCompoundTag(compound);
 
-		CarpetClientServer.sender(data, sender);
+		if (!CarpetClientServer.sender(data, sender)) {
+		    // Payload was too large, try large packets for newer CC versions
+		    NBTTagList boxes = compound.getTagList("Boxes", 9);
+		    compound.removeTag("Boxes");
+		    List<NBTTagCompound> allBoxes = new ArrayList<>();
+		    for (int i = 0; i < boxes.tagCount(); i++) {
+		        NBTTagList list = (NBTTagList) boxes.get(i);
+		        for (int j = 0; j < list.tagCount(); j++) {
+		            allBoxes.add(list.getCompoundTagAt(j));
+		        }
+		    }
+		    
+		    data = new PacketBuffer(Unpooled.buffer());
+		    data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS_START);
+		    data.writeCompoundTag(compound);
+		    data.writeVarInt(allBoxes.size());
+		    CarpetClientServer.sender(data, sender);
+		    
+		    for (NBTTagCompound box : allBoxes) {
+		        data = new PacketBuffer(Unpooled.buffer());
+		        data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS);
+		        data.writeCompoundTag(box);
+		        CarpetClientServer.sender(data, sender);
+		    }
+		}
 	}
 
 	public static void sendTickRateChanges() {

--- a/carpetmodSrc/carpet/carpetclient/CarpetClientMessageHandler.java
+++ b/carpetmodSrc/carpet/carpetclient/CarpetClientMessageHandler.java
@@ -13,137 +13,139 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.PacketBuffer;
 
 public class CarpetClientMessageHandler {
-	// Main packet data names
-	public static final int GUI_ALL_DATA = 0;
-	public static final int RULE_REQUEST = 1;
-	public static final int VILLAGE_MARKERS = 2;
-	public static final int BOUNDINGBOX_MARKERS = 3;
-	public static final int TICKRATE_CHANGES = 4;
-	public static final int LARGE_VILLAGE_MARKERS_START = 5;
-	public static final int LARGE_VILLAGE_MARKERS = 6;
-	public static final int LARGE_BOUNDINGBOX_MARKERS_START = 7;
-	public static final int LARGE_BOUNDINGBOX_MARKERS = 8;
+    // Main packet data names
+    public static final int GUI_ALL_DATA = 0;
+    public static final int RULE_REQUEST = 1;
+    public static final int VILLAGE_MARKERS = 2;
+    public static final int BOUNDINGBOX_MARKERS = 3;
+    public static final int TICKRATE_CHANGES = 4;
+    public static final int LARGE_VILLAGE_MARKERS_START = 5;
+    public static final int LARGE_VILLAGE_MARKERS = 6;
+    public static final int LARGE_BOUNDINGBOX_MARKERS_START = 7;
+    public static final int LARGE_BOUNDINGBOX_MARKERS = 8;
 
-	public static void handler(EntityPlayerMP sender, PacketBuffer data) {
-		int type = data.readInt();
+    public static void handler(EntityPlayerMP sender, PacketBuffer data) {
+        int type = data.readInt();
 
-		if (GUI_ALL_DATA == type) {
-			sendAllGUIOptions();
-		} else if (RULE_REQUEST == type) {
-			ruleRequest(sender, data);
-		} else if (VILLAGE_MARKERS == type) {
-			registerVillagerMarkers(sender, data);
-		} else if (BOUNDINGBOX_MARKERS == type) {
-			boundingboxRequest(sender, data);
-		}
-	}
+        if (GUI_ALL_DATA == type) {
+            sendAllGUIOptions();
+        } else if (RULE_REQUEST == type) {
+            ruleRequest(sender, data);
+        } else if (VILLAGE_MARKERS == type) {
+            registerVillagerMarkers(sender, data);
+        } else if (BOUNDINGBOX_MARKERS == type) {
+            boundingboxRequest(sender, data);
+        }
+    }
 
-	private static void registerVillagerMarkers(EntityPlayerMP sender, PacketBuffer data) {
-		CarpetClientMarkers.registerVillagerMarkers(sender, data);
-	}
+    private static void registerVillagerMarkers(EntityPlayerMP sender, PacketBuffer data) {
+        CarpetClientMarkers.registerVillagerMarkers(sender, data);
+    }
 
-	private static void boundingboxRequest(EntityPlayerMP sender, PacketBuffer data) {
-		CarpetClientMarkers.updateClientBoundingBoxMarkers(sender, data);
-	}
+    private static void boundingboxRequest(EntityPlayerMP sender, PacketBuffer data) {
+        CarpetClientMarkers.updateClientBoundingBoxMarkers(sender, data);
+    }
 
-	private static void ruleRequest(EntityPlayerMP sender, PacketBuffer data) {
-		CarpetClientRuleChanger.ruleChanger(sender, data);
-	}
+    private static void ruleRequest(EntityPlayerMP sender, PacketBuffer data) {
+        CarpetClientRuleChanger.ruleChanger(sender, data);
+    }
 
-	public static void sendAllGUIOptions() {
-		PacketBuffer data = new PacketBuffer(Unpooled.buffer());
-		data.writeInt(GUI_ALL_DATA);
+    public static void sendAllGUIOptions() {
+        PacketBuffer data = new PacketBuffer(Unpooled.buffer());
+        data.writeInt(GUI_ALL_DATA);
 
-		ArrayList<CarpetSettingEntry> list = CarpetSettings.getAllCarpetSettings();
+        ArrayList<CarpetSettingEntry> list = CarpetSettings.getAllCarpetSettings();
 
-		data.writeString(CarpetSettings.carpetVersion);
-		data.writeFloat(TickSpeed.tickrate);
-		data.writeInt(list.size());
-		for (CarpetSettingEntry cse : list) {
-			String rule = cse.getName();
-			String current = cse.getStringValue();
-			String[] options = cse.getOptions();
-			String def = cse.getDefault();
-			boolean isfloat = cse.getIsFloat();
+        data.writeString(CarpetSettings.carpetVersion);
+        data.writeFloat(TickSpeed.tickrate);
+        data.writeInt(list.size());
+        for (CarpetSettingEntry cse : list) {
+            String rule = cse.getName();
+            String current = cse.getStringValue();
+            String[] options = cse.getOptions();
+            String def = cse.getDefault();
+            boolean isfloat = cse.getIsFloat();
 
-			data.writeString(rule);
-			data.writeString(current);
-			data.writeString(def);
-			data.writeBoolean(isfloat);
-			// data.writeInt(options.length);
-			// for (String o : options) {
-			// data.writeString(o);
-			// }
-		}
+            data.writeString(rule);
+            data.writeString(current);
+            data.writeString(def);
+            data.writeBoolean(isfloat);
+            // data.writeInt(options.length);
+            // for (String o : options) {
+            // data.writeString(o);
+            // }
+        }
 
-		CarpetClientServer.sender(data);
-	}
+        CarpetClientServer.sender(data);
+    }
 
-	public static void sendNBTVillageData(EntityPlayerMP sender, NBTTagCompound compound) {
-		PacketBuffer data = new PacketBuffer(Unpooled.buffer());
-		data.writeInt(CarpetClientMessageHandler.VILLAGE_MARKERS);
+    public static void sendNBTVillageData(EntityPlayerMP sender, NBTTagCompound compound) {
+        PacketBuffer data = new PacketBuffer(Unpooled.buffer());
+        data.writeInt(CarpetClientMessageHandler.VILLAGE_MARKERS);
 
-		data.writeCompoundTag(compound);
+        data.writeCompoundTag(compound);
 
-		if (!CarpetClientServer.sender(data, sender)) {
-		    // Payload was too large, try large packets for newer CC versions
-		    NBTTagList villages = compound.getTagList("Villages", 10);
-		    
-		    data = new PacketBuffer(Unpooled.buffer());
-		    data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS_START);
-		    data.writeVarInt(villages.tagCount());
-		    CarpetClientServer.sender(data, sender);
-		    
-		    for (int i = 0; i < villages.tagCount(); i++) {
-		        NBTTagCompound tag = new NBTTagCompound();
-		        tag.setTag("Village", villages.getCompoundTagAt(i));
-		        
-		        data = new PacketBuffer(Unpooled.buffer());
-		        data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS);
-		        data.writeCompoundTag(tag);
-		        CarpetClientServer.sender(data, sender);
-		    }
-		}
-	}
+        if (!CarpetClientServer.sender(data, sender)) {
+            // Payload was too large, try large packets for newer CC versions
+            NBTTagList villages = compound.getTagList("Villages", 10);
+            
+            data = new PacketBuffer(Unpooled.buffer());
+            data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS_START);
+            data.writeVarInt(villages.tagCount());
+            CarpetClientServer.sender(data, sender);
+            
+            for (int i = 0; i < villages.tagCount(); i += 256) {
+                data = new PacketBuffer(Unpooled.buffer());
+                data.writeInt(CarpetClientMessageHandler.LARGE_VILLAGE_MARKERS);
+                data.writeByte(Math.min(villages.tagCount() - i - 1, 255));
+                for (int j = i; j < villages.tagCount() && j < i + 256; j++) {
+                    data.writeCompoundTag(villages.getCompoundTagAt(j));
+                }
+                CarpetClientServer.sender(data, sender);
+            }
+        }
+    }
 
-	public static void sendNBTBoundingboxData(EntityPlayerMP sender, NBTTagCompound compound) {
-		PacketBuffer data = new PacketBuffer(Unpooled.buffer());
-		data.writeInt(CarpetClientMessageHandler.BOUNDINGBOX_MARKERS);
+    public static void sendNBTBoundingboxData(EntityPlayerMP sender, NBTTagCompound compound) {
+        PacketBuffer data = new PacketBuffer(Unpooled.buffer());
+        data.writeInt(CarpetClientMessageHandler.BOUNDINGBOX_MARKERS);
 
-		data.writeCompoundTag(compound);
+        data.writeCompoundTag(compound);
 
-		if (!CarpetClientServer.sender(data, sender)) {
-		    // Payload was too large, try large packets for newer CC versions
-		    NBTTagList boxes = compound.getTagList("Boxes", 9);
-		    compound.removeTag("Boxes");
-		    List<NBTTagCompound> allBoxes = new ArrayList<>();
-		    for (int i = 0; i < boxes.tagCount(); i++) {
-		        NBTTagList list = (NBTTagList) boxes.get(i);
-		        for (int j = 0; j < list.tagCount(); j++) {
-		            allBoxes.add(list.getCompoundTagAt(j));
-		        }
-		    }
-		    
-		    data = new PacketBuffer(Unpooled.buffer());
-		    data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS_START);
-		    data.writeCompoundTag(compound);
-		    data.writeVarInt(allBoxes.size());
-		    CarpetClientServer.sender(data, sender);
-		    
-		    for (NBTTagCompound box : allBoxes) {
-		        data = new PacketBuffer(Unpooled.buffer());
-		        data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS);
-		        data.writeCompoundTag(box);
-		        CarpetClientServer.sender(data, sender);
-		    }
-		}
-	}
+        if (!CarpetClientServer.sender(data, sender)) {
+            // Payload was too large, try large packets for newer CC versions
+            NBTTagList boxes = compound.getTagList("Boxes", 9);
+            compound.removeTag("Boxes");
+            List<NBTTagCompound> allBoxes = new ArrayList<>();
+            for (int i = 0; i < boxes.tagCount(); i++) {
+                NBTTagList list = (NBTTagList) boxes.get(i);
+                for (int j = 0; j < list.tagCount(); j++) {
+                    allBoxes.add(list.getCompoundTagAt(j));
+                }
+            }
+            
+            data = new PacketBuffer(Unpooled.buffer());
+            data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS_START);
+            data.writeCompoundTag(compound);
+            data.writeVarInt(allBoxes.size());
+            CarpetClientServer.sender(data, sender);
+            
+            for (int i = 0; i < allBoxes.size(); i += 256) {
+                data = new PacketBuffer(Unpooled.buffer());
+                data.writeInt(CarpetClientMessageHandler.LARGE_BOUNDINGBOX_MARKERS);
+                data.writeByte(Math.min(allBoxes.size() - i - 1, 255));
+                for (int j = i; j < allBoxes.size() && j < i + 256; j++)
+                    data.writeCompoundTag(allBoxes.get(j));
+                CarpetClientServer.sender(data, sender);
+            }
+        }
+    }
 
-	public static void sendTickRateChanges() {
-		PacketBuffer data = new PacketBuffer(Unpooled.buffer());
-		data.writeInt(CarpetClientMessageHandler.TICKRATE_CHANGES);
-		data.writeFloat(TickSpeed.tickrate);
+    public static void sendTickRateChanges() {
+        PacketBuffer data = new PacketBuffer(Unpooled.buffer());
+        data.writeInt(CarpetClientMessageHandler.TICKRATE_CHANGES);
+        data.writeFloat(TickSpeed.tickrate);
 
-		CarpetClientServer.sender(data);
-	}
+        CarpetClientServer.sender(data);
+    }
 }

--- a/carpetmodSrc/carpet/carpetclient/CarpetClientServer.java
+++ b/carpetmodSrc/carpet/carpetclient/CarpetClientServer.java
@@ -52,7 +52,7 @@ public class CarpetClientServer {
         return players;
     }
 
-    public static void sender(PacketBuffer data)
+    public static boolean sender(PacketBuffer data)
     {
         try
         {
@@ -60,23 +60,27 @@ public class CarpetClientServer {
             for (EntityPlayerMP player : CarpetClientServer.getRegisteredPlayers()) {
                 player.connection.sendPacket(packet);
             }
+            return true;
         }
         catch (IllegalArgumentException exc)
         {
-            CarpetSettings.LOG.error("Village payload too large - skipping ...");
+            // Payload too large
+            return false;
         }
     }
 
-    public static void sender(PacketBuffer data, EntityPlayerMP player)
+    public static boolean sender(PacketBuffer data, EntityPlayerMP player)
     {
         try
         {
             SPacketCustomPayload packet = new SPacketCustomPayload(CARPET_CHANNEL_NAME, data);
             player.connection.sendPacket(packet);
+            return true;
         }
         catch (IllegalArgumentException exc)
         {
-            CarpetSettings.LOG.error("Village payload too large - skipping ...");
+            // Payload too large
+            return false;
         }
     }
 


### PR DESCRIPTION
#47 is caused by the fix to #5. However, rather than stopping the villages from being displayed it was causing buggy behaviour, so I thought it was worth a proper fix. I also applied the same fix to structure bounding boxes in case that might be affected.

To update the client with village information, carpet will first try to send the old "legacy" packet. I didn't remove this because I wanted it to still work for old carpetclient versions. We then catch the exception for if the payload is too large and if so try the new "large structure" update.
The large structure update sends an initial packet, followed by several packets sending the village information in batches of 256 villages per packet.
Outdated carpet clients will silently ignore these unrecognized packets. I have also PR'ed for carpet client to recognize these new packets.