### PR TITLE
Improved statistics (sub-items) and scoreboard (initialized to stat)

### DIFF
--- a/carpetmodSrc/carpet/helpers/StatHelper.java
+++ b/carpetmodSrc/carpet/helpers/StatHelper.java
@@ -2,14 +2,23 @@ package carpet.helpers;
 
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.minecraft.MinecraftSessionService;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.scoreboard.*;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.management.PlayerList;
 import net.minecraft.server.management.PlayerProfileCache;
 import net.minecraft.stats.StatBase;
+import net.minecraft.stats.StatCrafting;
 import net.minecraft.stats.StatisticsManager;
 import net.minecraft.stats.StatisticsManagerServer;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentTranslation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,6 +32,11 @@ public class StatHelper {
     private static final Logger LOGGER = LogManager.getLogger();
     private static Map<UUID, StatisticsManager> cache;
     private static long cacheTime;
+    private static final StatBase[] BLOCK_STATE_STATS = new StatBase[256 * 16];
+    private static final Int2ObjectMap<StatBase> CRAFT_META_STATS = new Int2ObjectOpenHashMap<>();
+    private static final Int2ObjectMap<StatBase> OBJECT_USE_META_STATS = new Int2ObjectOpenHashMap<>();
+    private static final Int2ObjectMap<StatBase> OBJECTS_PICKED_UP_META_STATS = new Int2ObjectOpenHashMap<>();
+    private static final Int2ObjectMap<StatBase> OBJECTS_DROPPED_META_STATS = new Int2ObjectOpenHashMap<>();
 
     public static File[] getStatFiles(MinecraftServer server) {
         File statsDir = new File(server.getWorld(0).getSaveHandler().getWorldDirectory(), "stats");
@@ -80,6 +94,110 @@ public class StatHelper {
             Score score = scoreboard.getOrCreateScore(username, objective);
             score.setScorePoints(value);
             LOGGER.info("Initialized score " + objective.getName() + " of " + username + " to " + value);
+        }
+    }
+
+    public static StatBase getBlockStateStats(IBlockState state) {
+        Block block = state.getBlock();
+        int id = Block.getIdFromBlock(block);
+        int meta = block.getMetaFromState(state);
+        return BLOCK_STATE_STATS[(id << 4) | meta];
+    }
+
+    public static StatBase getCraftStats(Item item, int meta) {
+        int id = Item.getIdFromItem(item);
+        return CRAFT_META_STATS.get((id << 4) | (meta & 0xf));
+    }
+
+    public static StatBase getObjectUseStats(Item item, int meta) {
+        int id = Item.getIdFromItem(item);
+        return OBJECT_USE_META_STATS.get((id << 4) | (meta & 0xf));
+    }
+
+    public static StatBase getObjectsPickedUpStats(Item item, int meta) {
+        int id = Item.getIdFromItem(item);
+        return OBJECTS_PICKED_UP_META_STATS.get((id << 4) | (meta & 0xf));
+    }
+
+    public static StatBase getDroppedObjectStats(Item item, int meta) {
+        int id = Item.getIdFromItem(item);
+        return OBJECTS_DROPPED_META_STATS.get((id << 4) | (meta & 0xf));
+    }
+
+    public static void addCraftStats(Item item, StatCrafting baseStat) {
+        int id = Item.getIdFromItem(item);
+        if (item.getHasSubtypes()) {
+            for (int meta = 0; meta < 16; meta++) {
+                int stateId = (id << 4) | meta;
+                ItemStack stackWithMeta = new ItemStack(item, 1, meta);
+                ITextComponent text = new TextComponentTranslation("stat.craftItem", stackWithMeta.getTextComponent());
+                StatSubItem statWithMeta = (StatSubItem) new StatSubItem(baseStat, meta, text).registerStat();
+                CRAFT_META_STATS.put(stateId, statWithMeta);
+            }
+        } else {
+            for (int meta = 0; meta < 16; meta++) {
+                int stateId = (id << 4) | meta;
+                CRAFT_META_STATS.put(stateId, baseStat);
+            }
+        }
+    }
+
+    public static void addMineStats(Block block, StatCrafting baseStat) {
+        Item item = Item.getItemFromBlock(block);
+        int id = Item.getIdFromItem(item);
+        if (item.getHasSubtypes()) {
+            for (int meta = 0; meta < 16; meta++) {
+                int stateId = (id << 4) | meta;
+                ItemStack stackWithMeta = new ItemStack(block, 1, meta);
+                ITextComponent text = new TextComponentTranslation("stat.mineBlock", stackWithMeta.getTextComponent());
+                StatSubItem statWithMeta = (StatSubItem) new StatSubItem(baseStat, meta, text).registerStat();
+                BLOCK_STATE_STATS[stateId] = statWithMeta;
+            }
+        } else {
+            for (int meta = 0; meta < 16; meta++) {
+                int stateId = (id << 4) | meta;
+                BLOCK_STATE_STATS[stateId] = baseStat;
+            }
+        }
+    }
+
+    public static void addUseStats(Item item, StatCrafting baseStat) {
+        int id = Item.getIdFromItem(item);
+        if (item.getHasSubtypes()) {
+            for (int meta = 0; meta < 16; meta++) {
+                int stateId = (id << 4) | meta;
+                ItemStack stackWithMeta = new ItemStack(item, 1, meta);
+                ITextComponent text = new TextComponentTranslation("stat.useItem", stackWithMeta.getTextComponent());
+                StatSubItem statWithMeta = (StatSubItem) new StatSubItem(baseStat, meta, text).registerStat();
+                OBJECT_USE_META_STATS.put(stateId, statWithMeta);
+            }
+        } else {
+            for (int meta = 0; meta < 16; meta++) {
+                int stateId = (id << 4) | meta;
+                OBJECT_USE_META_STATS.put(stateId, baseStat);
+            }
+        }
+    }
+
+    public static void addPickedUpAndDroppedStats(Item item, StatCrafting basePickupStat, StatCrafting baseDropStat) {
+        int id = Item.getIdFromItem(item);
+        if (item.getHasSubtypes()) {
+            for (int meta = 0; meta < 16; meta++) {
+                int stateId = (id << 4) | meta;
+                ItemStack stackWithMeta = new ItemStack(item, 1, meta);
+                ITextComponent textPickup = new TextComponentTranslation("stat.pickup", stackWithMeta.getTextComponent());
+                StatSubItem pickupWithMeta = (StatSubItem) new StatSubItem(basePickupStat, meta, textPickup).registerStat();
+                OBJECTS_PICKED_UP_META_STATS.put(stateId, pickupWithMeta);
+                ITextComponent textDrop = new TextComponentTranslation("stat.drop", stackWithMeta.getTextComponent());
+                StatSubItem dropWithMeta = (StatSubItem) new StatSubItem(baseDropStat, meta, textDrop).registerStat();
+                OBJECTS_DROPPED_META_STATS.put(stateId, dropWithMeta);
+            }
+        } else {
+            for (int meta = 0; meta < 16; meta++) {
+                int stateId = (id << 4) | meta;
+                OBJECTS_PICKED_UP_META_STATS.put(stateId, basePickupStat);
+                OBJECTS_DROPPED_META_STATS.put(stateId, baseDropStat);
+            }
         }
     }
 }

--- a/carpetmodSrc/carpet/helpers/StatHelper.java
+++ b/carpetmodSrc/carpet/helpers/StatHelper.java
@@ -1,0 +1,85 @@
+package carpet.helpers;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.scoreboard.*;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerList;
+import net.minecraft.server.management.PlayerProfileCache;
+import net.minecraft.stats.StatBase;
+import net.minecraft.stats.StatisticsManager;
+import net.minecraft.stats.StatisticsManagerServer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class StatHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static Map<UUID, StatisticsManager> cache;
+    private static long cacheTime;
+
+    public static File[] getStatFiles(MinecraftServer server) {
+        File statsDir = new File(server.getWorld(0).getSaveHandler().getWorldDirectory(), "stats");
+        return statsDir.listFiles((dir, name) -> name.endsWith(".json"));
+    }
+
+    public static Map<UUID, StatisticsManager> getAllStatistics(MinecraftServer server) {
+        if (cache != null && server.getTickCounter() - cacheTime < 100) return cache;
+        File[] files = getStatFiles(server);
+        HashMap<UUID, StatisticsManager> stats = new HashMap<>();
+        PlayerList players = server.getPlayerList();
+        for (File file : files) {
+            String filename = file.getName();
+            String uuidString = filename.substring(0, filename.lastIndexOf(".json"));
+            try {
+                UUID uuid = UUID.fromString(uuidString);
+                EntityPlayerMP player = players.getPlayerByUUID(uuid);
+                if (player != null) {
+                    stats.put(uuid, players.getPlayerStatsFile(player));
+                } else {
+                    StatisticsManagerServer manager = new StatisticsManagerServer(server, file);
+                    manager.readStatFile();
+                    stats.put(uuid, manager);
+                }
+            } catch (IllegalArgumentException ignored) {}
+        }
+        cache = stats;
+        cacheTime = server.getTickCounter();
+        return stats;
+    }
+
+    @Nullable
+    public static String getUsername(MinecraftServer server, UUID uuid) {
+        PlayerProfileCache profileCache = server.getPlayerProfileCache();
+        GameProfile profile = profileCache.getProfileByUUID(uuid);
+        if (profile != null) return profile.getName();
+        MinecraftSessionService sessionService = server.getMinecraftSessionService();
+        profile = sessionService.fillProfileProperties(new GameProfile(uuid, null), false);
+        if (profile.isComplete()) return profile.getName();
+        LOGGER.warn("Could not find name of user " + uuid);
+        return null;
+    }
+
+    public static void initialize(Scoreboard scoreboard, MinecraftServer server, ScoreObjective objective) {
+        LOGGER.info("Initializing " + objective);
+        IScoreCriteria criteria = objective.getCriteria();
+        if (!(criteria instanceof ScoreCriteriaStat)) return;
+        StatBase stat = ((ScoreCriteriaStat) criteria).stat;
+        for (Map.Entry<UUID, StatisticsManager> statEntry : getAllStatistics(server).entrySet()) {
+            StatisticsManager stats = statEntry.getValue();
+            int value = stats.readStat(stat);
+            if (value == 0) continue;
+            String username = getUsername(server, statEntry.getKey());
+            if (username == null) continue;
+            Score score = scoreboard.getOrCreateScore(username, objective);
+            score.setScorePoints(value);
+            LOGGER.info("Initialized score " + objective.getName() + " of " + username + " to " + value);
+        }
+    }
+}

--- a/carpetmodSrc/carpet/helpers/StatSubItem.java
+++ b/carpetmodSrc/carpet/helpers/StatSubItem.java
@@ -1,0 +1,17 @@
+package carpet.helpers;
+
+import net.minecraft.stats.StatCrafting;
+import net.minecraft.util.text.ITextComponent;
+
+public class StatSubItem extends StatCrafting {
+    private final StatCrafting base;
+
+    public StatSubItem(StatCrafting base, int meta, ITextComponent translation) {
+        super(base.statId, "." + meta, translation, base.item);
+        this.base = base;
+    }
+
+    public StatCrafting getBase() {
+        return this.base;
+    }
+}

--- a/patches/net/minecraft/block/Block.java.patch
+++ b/patches/net/minecraft/block/Block.java.patch
@@ -36,3 +36,15 @@
          }
      }
  
+@@ -593,7 +597,10 @@
+ 
+     public void func_180657_a(World p_180657_1_, EntityPlayer p_180657_2_, BlockPos p_180657_3_, IBlockState p_180657_4_, @Nullable TileEntity p_180657_5_, ItemStack p_180657_6_)
+     {
+-        p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++        // CM
++        // player.addStat(StatList.getBlockStats(this));
++        p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++        // CM END
+         p_180657_2_.func_71020_j(0.005F);
+ 
+         if (this.func_149700_E() && EnchantmentHelper.func_77506_a(Enchantments.field_185306_r, p_180657_6_) > 0)

--- a/patches/net/minecraft/block/Block.java.patch
+++ b/patches/net/minecraft/block/Block.java.patch
@@ -1,15 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/block/Block.java
 +++ ../src-work/minecraft/net/minecraft/block/Block.java
-@@ -47,6 +47,8 @@
+@@ -47,6 +47,9 @@
  import net.minecraft.world.IBlockAccess;
  import net.minecraft.world.World;
  
 +import carpet.helpers.CapturedDrops;
++import carpet.helpers.StatHelper;
 +
  public class Block
  {
      private static final ResourceLocation field_176230_a = new ResourceLocation("air");
-@@ -235,7 +237,7 @@
+@@ -235,7 +238,7 @@
          return this;
      }
  
@@ -18,7 +19,7 @@
      {
          this.field_149786_r = p_149713_1_;
          return this;
-@@ -327,7 +329,7 @@
+@@ -327,7 +330,7 @@
          return this.field_149782_v;
      }
  
@@ -27,7 +28,7 @@
      {
          this.field_149789_z = p_149675_1_;
          return this;
-@@ -490,6 +492,8 @@
+@@ -490,6 +493,8 @@
              EntityItem entityitem = new EntityItem(p_180635_0_, (double)p_180635_1_.func_177958_n() + d0, (double)p_180635_1_.func_177956_o() + d1, (double)p_180635_1_.func_177952_p() + d2, p_180635_2_);
              entityitem.func_174869_p();
              p_180635_0_.func_72838_d(entityitem);
@@ -36,14 +37,14 @@
          }
      }
  
-@@ -593,7 +597,10 @@
+@@ -593,7 +598,10 @@
  
      public void func_180657_a(World p_180657_1_, EntityPlayer p_180657_2_, BlockPos p_180657_3_, IBlockState p_180657_4_, @Nullable TileEntity p_180657_5_, ItemStack p_180657_6_)
      {
 -        p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +        // CM
 +        // player.addStat(StatList.getBlockStats(this));
-+        p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++        p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +        // CM END
          p_180657_2_.func_71020_j(0.005F);
  

--- a/patches/net/minecraft/block/BlockContainer.java.patch
+++ b/patches/net/minecraft/block/BlockContainer.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockContainer.java
++++ ../src-work/minecraft/net/minecraft/block/BlockContainer.java
+@@ -56,7 +56,10 @@
+     {
+         if (p_180657_5_ instanceof IWorldNameable && ((IWorldNameable)p_180657_5_).func_145818_k_())
+         {
+-            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++            // CM
++            // player.addStat(StatList.getBlockStats(this));
++            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            // CM END
+             p_180657_2_.func_71020_j(0.005F);
+ 
+             if (p_180657_1_.field_72995_K)

--- a/patches/net/minecraft/block/BlockContainer.java.patch
+++ b/patches/net/minecraft/block/BlockContainer.java.patch
@@ -1,13 +1,30 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockContainer.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockContainer.java
-@@ -56,7 +56,10 @@
+@@ -1,6 +1,7 @@
+ package net.minecraft.block;
+ 
+ import javax.annotation.Nullable;
++
+ import net.minecraft.block.material.MapColor;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+@@ -18,6 +19,8 @@
+ import net.minecraft.world.IWorldNameable;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public abstract class BlockContainer extends Block implements ITileEntityProvider
+ {
+     protected BlockContainer(Material p_i45386_1_)
+@@ -56,7 +59,10 @@
      {
          if (p_180657_5_ instanceof IWorldNameable && ((IWorldNameable)p_180657_5_).func_145818_k_())
          {
 -            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +            // CM
 +            // player.addStat(StatList.getBlockStats(this));
-+            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +            // CM END
              p_180657_2_.func_71020_j(0.005F);
  

--- a/patches/net/minecraft/block/BlockDeadBush.java.patch
+++ b/patches/net/minecraft/block/BlockDeadBush.java.patch
@@ -1,13 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockDeadBush.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockDeadBush.java
-@@ -60,7 +60,10 @@
+@@ -17,6 +17,8 @@
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class BlockDeadBush extends BlockBush
+ {
+     protected static final AxisAlignedBB field_185516_a = new AxisAlignedBB(0.09999999403953552D, 0.0D, 0.09999999403953552D, 0.8999999761581421D, 0.800000011920929D, 0.8999999761581421D);
+@@ -60,7 +62,10 @@
      {
          if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
          {
 -            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +            // CM
 +            // player.addStat(StatList.getBlockStats(this));
-+            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +            // CM END
              func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Blocks.field_150330_I, 1, 0));
          }

--- a/patches/net/minecraft/block/BlockDeadBush.java.patch
+++ b/patches/net/minecraft/block/BlockDeadBush.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockDeadBush.java
++++ ../src-work/minecraft/net/minecraft/block/BlockDeadBush.java
+@@ -60,7 +60,10 @@
+     {
+         if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
+         {
+-            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++            // CM
++            // player.addStat(StatList.getBlockStats(this));
++            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            // CM END
+             func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Blocks.field_150330_I, 1, 0));
+         }
+         else

--- a/patches/net/minecraft/block/BlockDoublePlant.java.patch
+++ b/patches/net/minecraft/block/BlockDoublePlant.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockDoublePlant.java
++++ ../src-work/minecraft/net/minecraft/block/BlockDoublePlant.java
+@@ -217,7 +217,10 @@
+         }
+         else
+         {
+-            p_176489_4_.func_71029_a(StatList.func_188055_a(this));
++            // CM
++            // player.addStat(StatList.getBlockStats(this));
++            p_176489_4_.func_71029_a(StatList.getBlockStateStats(p_176489_3_));
++            // CM END
+             int i = (blockdoubleplant$enumplanttype == BlockDoublePlant.EnumPlantType.GRASS ? BlockTallGrass.EnumType.GRASS : BlockTallGrass.EnumType.FERN).func_177044_a();
+             func_180635_a(p_176489_1_, p_176489_2_, new ItemStack(Blocks.field_150329_H, 2, i));
+             return true;

--- a/patches/net/minecraft/block/BlockDoublePlant.java.patch
+++ b/patches/net/minecraft/block/BlockDoublePlant.java.patch
@@ -1,13 +1,30 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockDoublePlant.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockDoublePlant.java
-@@ -217,7 +217,10 @@
+@@ -2,6 +2,7 @@
+ 
+ import java.util.Random;
+ import javax.annotation.Nullable;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.properties.IProperty;
+ import net.minecraft.block.properties.PropertyEnum;
+@@ -22,6 +23,8 @@
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class BlockDoublePlant extends BlockBush implements IGrowable
+ {
+     public static final PropertyEnum<BlockDoublePlant.EnumPlantType> field_176493_a = PropertyEnum.<BlockDoublePlant.EnumPlantType>func_177709_a("variant", BlockDoublePlant.EnumPlantType.class);
+@@ -217,7 +220,10 @@
          }
          else
          {
 -            p_176489_4_.func_71029_a(StatList.func_188055_a(this));
 +            // CM
 +            // player.addStat(StatList.getBlockStats(this));
-+            p_176489_4_.func_71029_a(StatList.getBlockStateStats(p_176489_3_));
++            p_176489_4_.func_71029_a(StatHelper.getBlockStateStats(p_176489_3_));
 +            // CM END
              int i = (blockdoubleplant$enumplanttype == BlockDoublePlant.EnumPlantType.GRASS ? BlockTallGrass.EnumType.GRASS : BlockTallGrass.EnumType.FERN).func_177044_a();
              func_180635_a(p_176489_1_, p_176489_2_, new ItemStack(Blocks.field_150329_H, 2, i));

--- a/patches/net/minecraft/block/BlockIce.java.patch
+++ b/patches/net/minecraft/block/BlockIce.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockIce.java
++++ ../src-work/minecraft/net/minecraft/block/BlockIce.java
+@@ -29,7 +29,10 @@
+ 
+     public void func_180657_a(World p_180657_1_, EntityPlayer p_180657_2_, BlockPos p_180657_3_, IBlockState p_180657_4_, @Nullable TileEntity p_180657_5_, ItemStack p_180657_6_)
+     {
+-        p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++        // CM
++        // player.addStat(StatList.getBlockStats(this));
++        p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++        // CM END
+         p_180657_2_.func_71020_j(0.005F);
+ 
+         if (this.func_149700_E() && EnchantmentHelper.func_77506_a(Enchantments.field_185306_r, p_180657_6_) > 0)

--- a/patches/net/minecraft/block/BlockIce.java.patch
+++ b/patches/net/minecraft/block/BlockIce.java.patch
@@ -1,13 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockIce.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockIce.java
-@@ -29,7 +29,10 @@
+@@ -17,6 +17,8 @@
+ import net.minecraft.world.EnumSkyBlock;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class BlockIce extends BlockBreakable
+ {
+     public BlockIce()
+@@ -29,7 +31,10 @@
  
      public void func_180657_a(World p_180657_1_, EntityPlayer p_180657_2_, BlockPos p_180657_3_, IBlockState p_180657_4_, @Nullable TileEntity p_180657_5_, ItemStack p_180657_6_)
      {
 -        p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +        // CM
 +        // player.addStat(StatList.getBlockStats(this));
-+        p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++        p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +        // CM END
          p_180657_2_.func_71020_j(0.005F);
  

--- a/patches/net/minecraft/block/BlockNewLeaf.java.patch
+++ b/patches/net/minecraft/block/BlockNewLeaf.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockNewLeaf.java
++++ ../src-work/minecraft/net/minecraft/block/BlockNewLeaf.java
+@@ -90,7 +90,10 @@
+     {
+         if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
+         {
+-            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++            // CM
++            // player.addStat(StatList.getBlockStats(this));
++            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            // CM END
+             func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Item.func_150898_a(this), 1, ((BlockPlanks.EnumType)p_180657_4_.func_177229_b(field_176240_P)).func_176839_a() - 4));
+         }
+         else

--- a/patches/net/minecraft/block/BlockNewLeaf.java.patch
+++ b/patches/net/minecraft/block/BlockNewLeaf.java.patch
@@ -1,13 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockNewLeaf.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockNewLeaf.java
-@@ -90,7 +90,10 @@
+@@ -15,6 +15,8 @@
+ import net.minecraft.util.math.BlockPos;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class BlockNewLeaf extends BlockLeaves
+ {
+     public static final PropertyEnum<BlockPlanks.EnumType> field_176240_P = PropertyEnum.<BlockPlanks.EnumType>func_177708_a("variant", BlockPlanks.EnumType.class, new Predicate<BlockPlanks.EnumType>()
+@@ -90,7 +92,10 @@
      {
          if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
          {
 -            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +            // CM
 +            // player.addStat(StatList.getBlockStats(this));
-+            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +            // CM END
              func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Item.func_150898_a(this), 1, ((BlockPlanks.EnumType)p_180657_4_.func_177229_b(field_176240_P)).func_176839_a() - 4));
          }

--- a/patches/net/minecraft/block/BlockOldLeaf.java.patch
+++ b/patches/net/minecraft/block/BlockOldLeaf.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockOldLeaf.java
++++ ../src-work/minecraft/net/minecraft/block/BlockOldLeaf.java
+@@ -90,7 +90,10 @@
+     {
+         if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
+         {
+-            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++            // CM
++            // player.addStat(StatList.getBlockStats(this));
++            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            // CM END
+             func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Item.func_150898_a(this), 1, ((BlockPlanks.EnumType)p_180657_4_.func_177229_b(field_176239_P)).func_176839_a()));
+         }
+         else

--- a/patches/net/minecraft/block/BlockOldLeaf.java.patch
+++ b/patches/net/minecraft/block/BlockOldLeaf.java.patch
@@ -1,13 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockOldLeaf.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockOldLeaf.java
-@@ -90,7 +90,10 @@
+@@ -15,6 +15,8 @@
+ import net.minecraft.util.math.BlockPos;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class BlockOldLeaf extends BlockLeaves
+ {
+     public static final PropertyEnum<BlockPlanks.EnumType> field_176239_P = PropertyEnum.<BlockPlanks.EnumType>func_177708_a("variant", BlockPlanks.EnumType.class, new Predicate<BlockPlanks.EnumType>()
+@@ -90,7 +92,10 @@
      {
          if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
          {
 -            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +            // CM
 +            // player.addStat(StatList.getBlockStats(this));
-+            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +            // CM END
              func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Item.func_150898_a(this), 1, ((BlockPlanks.EnumType)p_180657_4_.func_177229_b(field_176239_P)).func_176839_a()));
          }

--- a/patches/net/minecraft/block/BlockSnow.java.patch
+++ b/patches/net/minecraft/block/BlockSnow.java.patch
@@ -1,13 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockSnow.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockSnow.java
-@@ -114,7 +114,10 @@
+@@ -23,6 +23,8 @@
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class BlockSnow extends Block
+ {
+     public static final PropertyInteger field_176315_a = PropertyInteger.func_177719_a("layers", 1, 8);
+@@ -114,7 +116,10 @@
      {
          func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Items.field_151126_ay, ((Integer)p_180657_4_.func_177229_b(field_176315_a)).intValue() + 1, 0));
          p_180657_1_.func_175698_g(p_180657_3_);
 -        p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +        // CM
 +        // player.addStat(StatList.getBlockStats(this));
-+        p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++        p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +        // CM END
      }
  

--- a/patches/net/minecraft/block/BlockSnow.java.patch
+++ b/patches/net/minecraft/block/BlockSnow.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockSnow.java
++++ ../src-work/minecraft/net/minecraft/block/BlockSnow.java
+@@ -114,7 +114,10 @@
+     {
+         func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Items.field_151126_ay, ((Integer)p_180657_4_.func_177229_b(field_176315_a)).intValue() + 1, 0));
+         p_180657_1_.func_175698_g(p_180657_3_);
+-        p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++        // CM
++        // player.addStat(StatList.getBlockStats(this));
++        p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++        // CM END
+     }
+ 
+     public Item func_180660_a(IBlockState p_180660_1_, Random p_180660_2_, int p_180660_3_)

--- a/patches/net/minecraft/block/BlockTallGrass.java.patch
+++ b/patches/net/minecraft/block/BlockTallGrass.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockTallGrass.java
++++ ../src-work/minecraft/net/minecraft/block/BlockTallGrass.java
+@@ -60,7 +60,10 @@
+     {
+         if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
+         {
+-            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++            // CM
++            // player.addStat(StatList.getBlockStats(this));
++            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            // CM END
+             func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Blocks.field_150329_H, 1, ((BlockTallGrass.EnumType)p_180657_4_.func_177229_b(field_176497_a)).func_177044_a()));
+         }
+         else

--- a/patches/net/minecraft/block/BlockTallGrass.java.patch
+++ b/patches/net/minecraft/block/BlockTallGrass.java.patch
@@ -1,13 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockTallGrass.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockTallGrass.java
-@@ -60,7 +60,10 @@
+@@ -20,6 +20,8 @@
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class BlockTallGrass extends BlockBush implements IGrowable
+ {
+     public static final PropertyEnum<BlockTallGrass.EnumType> field_176497_a = PropertyEnum.<BlockTallGrass.EnumType>func_177709_a("type", BlockTallGrass.EnumType.class);
+@@ -60,7 +62,10 @@
      {
          if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
          {
 -            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +            // CM
 +            // player.addStat(StatList.getBlockStats(this));
-+            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +            // CM END
              func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Blocks.field_150329_H, 1, ((BlockTallGrass.EnumType)p_180657_4_.func_177229_b(field_176497_a)).func_177044_a()));
          }

--- a/patches/net/minecraft/block/BlockVine.java.patch
+++ b/patches/net/minecraft/block/BlockVine.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockVine.java
++++ ../src-work/minecraft/net/minecraft/block/BlockVine.java
+@@ -343,7 +343,10 @@
+     {
+         if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
+         {
+-            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++            // CM
++            // player.addStat(StatList.getBlockStats(this));
++            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            // CM END
+             func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Blocks.field_150395_bd, 1, 0));
+         }
+         else

--- a/patches/net/minecraft/block/BlockVine.java.patch
+++ b/patches/net/minecraft/block/BlockVine.java.patch
@@ -1,13 +1,31 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockVine.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockVine.java
-@@ -343,7 +343,10 @@
+@@ -2,6 +2,8 @@
+ 
+ import java.util.Random;
+ import javax.annotation.Nullable;
++
++import carpet.helpers.StatHelper;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.properties.IProperty;
+ import net.minecraft.block.properties.PropertyBool;
+@@ -25,6 +27,8 @@
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class BlockVine extends Block
+ {
+     public static final PropertyBool field_176277_a = PropertyBool.func_177716_a("up");
+@@ -343,7 +347,10 @@
      {
          if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
          {
 -            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +            // CM
 +            // player.addStat(StatList.getBlockStats(this));
-+            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +            // CM END
              func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Blocks.field_150395_bd, 1, 0));
          }

--- a/patches/net/minecraft/block/BlockWeb.java.patch
+++ b/patches/net/minecraft/block/BlockWeb.java.patch
@@ -1,13 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockWeb.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockWeb.java
-@@ -62,7 +62,10 @@
+@@ -19,6 +19,8 @@
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class BlockWeb extends Block
+ {
+     public BlockWeb()
+@@ -62,7 +64,10 @@
      {
          if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
          {
 -            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
 +            // CM
 +            // player.addStat(StatList.getBlockStats(this));
-+            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            p_180657_2_.func_71029_a(StatHelper.getBlockStateStats(p_180657_4_));
 +            // CM END
              func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Item.func_150898_a(this), 1));
          }

--- a/patches/net/minecraft/block/BlockWeb.java.patch
+++ b/patches/net/minecraft/block/BlockWeb.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockWeb.java
++++ ../src-work/minecraft/net/minecraft/block/BlockWeb.java
+@@ -62,7 +62,10 @@
+     {
+         if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
+         {
+-            p_180657_2_.func_71029_a(StatList.func_188055_a(this));
++            // CM
++            // player.addStat(StatList.getBlockStats(this));
++            p_180657_2_.func_71029_a(StatList.getBlockStateStats(p_180657_4_));
++            // CM END
+             func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Item.func_150898_a(this), 1));
+         }
+         else

--- a/patches/net/minecraft/command/server/CommandScoreboard.java.patch
+++ b/patches/net/minecraft/command/server/CommandScoreboard.java.patch
@@ -1,0 +1,37 @@
+--- ../src-base/minecraft/net/minecraft/command/server/CommandScoreboard.java
++++ ../src-work/minecraft/net/minecraft/command/server/CommandScoreboard.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.command.server;
+ 
++import carpet.helpers.StatHelper;
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.Sets;
+ import java.util.Arrays;
+@@ -416,18 +417,18 @@
+                     throw new SyntaxErrorException("commands.scoreboard.objectives.add.displayTooLong", new Object[] {s2, Integer.valueOf(32)});
+                 }
+ 
+-                if (s2.isEmpty())
+-                {
+-                    scoreboard.func_96535_a(s, iscorecriteria);
+-                }
+-                else
+-                {
+-                    scoreboard.func_96535_a(s, iscorecriteria).func_96681_a(s2);
+-                }
++                // CM
++                ScoreObjective objective = scoreboard.func_96535_a(s, iscorecriteria);
++                if (!s2.isEmpty()) objective.func_96681_a(s2);
++                StatHelper.initialize(scoreboard, p_184908_4_, objective);
++                // CM END
+             }
+             else
+             {
+-                scoreboard.func_96535_a(s, iscorecriteria);
++                // CM
++                ScoreObjective objective = scoreboard.func_96535_a(s, iscorecriteria);
++                StatHelper.initialize(scoreboard, p_184908_4_, objective);
++                // CM END
+             }
+ 
+             func_152373_a(p_184908_1_, this, "commands.scoreboard.objectives.add.success", new Object[] {s});

--- a/patches/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/net/minecraft/entity/item/EntityItem.java.patch
@@ -1,6 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/entity/item/EntityItem.java
 +++ ../src-work/minecraft/net/minecraft/entity/item/EntityItem.java
-@@ -35,6 +35,8 @@
+@@ -1,6 +1,7 @@
+ package net.minecraft.entity.item;
+ 
+ import javax.annotation.Nullable;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.entity.Entity;
+ import net.minecraft.entity.MoverType;
+@@ -25,6 +26,8 @@
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
++import carpet.helpers.StatHelper;
++
+ public class EntityItem extends Entity
+ {
+     private static final Logger field_145803_d = LogManager.getLogger();
+@@ -35,6 +38,8 @@
      private String field_145801_f;
      private String field_145802_g;
      public float field_70290_d;
@@ -9,7 +26,7 @@
  
      public EntityItem(World p_i1709_1_, double p_i1709_2_, double p_i1709_4_, double p_i1709_6_)
      {
-@@ -221,8 +223,23 @@
+@@ -221,8 +226,23 @@
                      }
                      else if (itemstack1.func_190916_E() + itemstack.func_190916_E() > itemstack1.func_77976_d())
                      {
@@ -33,17 +50,17 @@
                      else
                      {
                          itemstack1.func_190917_f(itemstack.func_190916_E());
-@@ -376,7 +393,8 @@
+@@ -376,7 +396,8 @@
                      itemstack.func_190920_e(i);
                  }
  
 -                p_70100_1_.func_71064_a(StatList.func_188056_d(item), i);
 +                // CM add meta
-+                p_70100_1_.func_71064_a(StatList.getObjectsPickedUpStats(item, itemstack.func_77960_j()), i);
++                p_70100_1_.func_71064_a(StatHelper.getObjectsPickedUpStats(item, itemstack.func_77960_j()), i);
              }
          }
      }
-@@ -470,4 +488,9 @@
+@@ -470,4 +491,9 @@
          this.func_174871_r();
          this.field_70292_b = 5999;
      }

--- a/patches/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/net/minecraft/entity/item/EntityItem.java.patch
@@ -33,7 +33,17 @@
                      else
                      {
                          itemstack1.func_190917_f(itemstack.func_190916_E());
-@@ -470,4 +487,9 @@
+@@ -376,7 +393,8 @@
+                     itemstack.func_190920_e(i);
+                 }
+ 
+-                p_70100_1_.func_71064_a(StatList.func_188056_d(item), i);
++                // CM add meta
++                p_70100_1_.func_71064_a(StatList.getObjectsPickedUpStats(item, itemstack.func_77960_j()), i);
+             }
+         }
+     }
+@@ -470,4 +488,9 @@
          this.func_174871_r();
          this.field_70292_b = 5999;
      }

--- a/patches/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/player/EntityPlayer.java
 +++ ../src-work/minecraft/net/minecraft/entity/player/EntityPlayer.java
-@@ -91,6 +91,12 @@
+@@ -91,6 +91,13 @@
  import net.minecraft.world.World;
  import net.minecraft.world.WorldServer;
  
@@ -9,11 +9,12 @@
 +import carpet.logging.logHelpers.DamageReporter;
 +import carpet.helpers.PortalHelper;
 +import carpet.logging.LoggerRegistry;
++import carpet.helpers.StatHelper;
 +
  public abstract class EntityPlayer extends EntityLivingBase
  {
      private static final DataParameter<Float> field_184829_a = EntityDataManager.<Float>func_187226_a(EntityPlayer.class, DataSerializers.field_187193_c);
-@@ -364,6 +370,15 @@
+@@ -364,6 +371,15 @@
  
      public int func_82145_z()
      {
@@ -29,7 +30,7 @@
          return this.field_71075_bZ.field_75102_a ? 1 : 80;
      }
  
-@@ -530,7 +545,9 @@
+@@ -530,7 +546,9 @@
          this.func_192028_j(this.func_192023_dk());
          this.func_192028_j(this.func_192025_dl());
  
@@ -40,16 +41,16 @@
          {
              this.func_192030_dh();
          }
-@@ -692,7 +709,7 @@
+@@ -692,7 +710,7 @@
              {
                  if (!itemstack.func_190926_b())
                  {
 -                    this.func_71064_a(StatList.func_188058_e(itemstack.func_77973_b()), p_146097_1_.func_190916_E());
-+                    this.func_71064_a(StatList.getDroppedObjectStats(itemstack.func_77973_b(), itemstack.func_77960_j()), p_146097_1_.func_190916_E());
++                    this.func_71064_a(StatHelper.getDroppedObjectStats(itemstack.func_77973_b(), itemstack.func_77960_j()), p_146097_1_.func_190916_E());
                  }
  
                  this.func_71029_a(StatList.field_75952_v);
-@@ -908,10 +925,23 @@
+@@ -908,10 +926,23 @@
                      this.func_70999_a(true, true, false);
                  }
  
@@ -74,7 +75,7 @@
                      if (this.field_70170_p.func_175659_aa() == EnumDifficulty.PEACEFUL)
                      {
                          p_70097_2_ = 0.0F;
-@@ -926,6 +956,7 @@
+@@ -926,6 +957,7 @@
                      {
                          p_70097_2_ = p_70097_2_ * 3.0F / 2.0F;
                      }
@@ -82,7 +83,7 @@
                  }
  
                  return p_70097_2_ == 0.0F ? false : super.func_70097_a(p_70097_1_, p_70097_2_);
-@@ -1008,16 +1039,22 @@
+@@ -1008,16 +1040,22 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -105,7 +106,7 @@
                  this.func_70606_j(this.func_110143_aJ() - p_70665_2_);
                  this.func_110142_aN().func_94547_a(p_70665_1_, f1, p_70665_2_);
  
-@@ -1027,6 +1064,12 @@
+@@ -1027,6 +1065,12 @@
                  }
              }
          }
@@ -118,7 +119,7 @@
      }
  
      public void func_175141_a(TileEntitySign p_175141_1_)
-@@ -1227,19 +1270,33 @@
+@@ -1227,19 +1271,33 @@
                          {
                              float f3 = 1.0F + EnchantmentHelper.func_191527_a(this) * f;
  
@@ -152,7 +153,7 @@
                          if (p_71059_1_ instanceof EntityPlayerMP && p_71059_1_.field_70133_I)
                          {
                              ((EntityPlayerMP)p_71059_1_).field_71135_a.func_147359_a(new SPacketEntityVelocity(p_71059_1_));
-@@ -1333,6 +1390,13 @@
+@@ -1333,6 +1391,13 @@
                      }
                  }
              }
@@ -166,7 +167,7 @@
          }
      }
  
-@@ -2044,6 +2108,20 @@
+@@ -2044,6 +2109,20 @@
          this.func_192031_i(new NBTTagCompound());
      }
  
@@ -187,7 +188,7 @@
      private void func_192026_k(@Nullable NBTTagCompound p_192026_1_)
      {
          if (!this.field_70170_p.field_72995_K && !p_192026_1_.func_82582_d())
-@@ -2307,6 +2385,13 @@
+@@ -2307,6 +2386,13 @@
      {
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }

--- a/patches/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -40,6 +40,15 @@
          {
              this.func_192030_dh();
          }
+@@ -692,7 +709,7 @@
+             {
+                 if (!itemstack.func_190926_b())
+                 {
+-                    this.func_71064_a(StatList.func_188058_e(itemstack.func_77973_b()), p_146097_1_.func_190916_E());
++                    this.func_71064_a(StatList.getDroppedObjectStats(itemstack.func_77973_b(), itemstack.func_77960_j()), p_146097_1_.func_190916_E());
+                 }
+ 
+                 this.func_71029_a(StatList.field_75952_v);
 @@ -908,10 +925,23 @@
                      this.func_70999_a(true, true, false);
                  }

--- a/patches/net/minecraft/item/ItemFood.java.patch
+++ b/patches/net/minecraft/item/ItemFood.java.patch
@@ -1,12 +1,21 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemFood.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemFood.java
-@@ -46,7 +46,8 @@
+@@ -14,6 +14,8 @@
+ import net.minecraft.util.SoundCategory;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public class ItemFood extends Item
+ {
+     public final int field_77855_a;
+@@ -46,7 +48,8 @@
              entityplayer.func_71024_bL().func_151686_a(this, p_77654_1_);
              p_77654_2_.func_184148_a((EntityPlayer)null, entityplayer.field_70165_t, entityplayer.field_70163_u, entityplayer.field_70161_v, SoundEvents.field_187739_dZ, SoundCategory.PLAYERS, 0.5F, p_77654_2_.field_73012_v.nextFloat() * 0.1F + 0.9F);
              this.func_77849_c(p_77654_1_, p_77654_2_, entityplayer);
 -            entityplayer.func_71029_a(StatList.func_188057_b(this));
 +            // CM add meta
-+            entityplayer.func_71029_a(StatList.getObjectUseStats(this, p_77654_1_.func_77960_j()));
++            entityplayer.func_71029_a(StatHelper.getObjectUseStats(this, p_77654_1_.func_77960_j()));
  
              if (entityplayer instanceof EntityPlayerMP)
              {

--- a/patches/net/minecraft/item/ItemFood.java.patch
+++ b/patches/net/minecraft/item/ItemFood.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemFood.java
++++ ../src-work/minecraft/net/minecraft/item/ItemFood.java
+@@ -46,7 +46,8 @@
+             entityplayer.func_71024_bL().func_151686_a(this, p_77654_1_);
+             p_77654_2_.func_184148_a((EntityPlayer)null, entityplayer.field_70165_t, entityplayer.field_70163_u, entityplayer.field_70161_v, SoundEvents.field_187739_dZ, SoundCategory.PLAYERS, 0.5F, p_77654_2_.field_73012_v.nextFloat() * 0.1F + 0.9F);
+             this.func_77849_c(p_77654_1_, p_77654_2_, entityplayer);
+-            entityplayer.func_71029_a(StatList.func_188057_b(this));
++            // CM add meta
++            entityplayer.func_71029_a(StatList.getObjectUseStats(this, p_77654_1_.func_77960_j()));
+ 
+             if (entityplayer instanceof EntityPlayerMP)
+             {

--- a/patches/net/minecraft/item/ItemStack.java.patch
+++ b/patches/net/minecraft/item/ItemStack.java.patch
@@ -1,6 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemStack.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemStack.java
-@@ -207,7 +207,9 @@
+@@ -169,7 +169,8 @@
+ 
+         if (enumactionresult == EnumActionResult.SUCCESS)
+         {
+-            p_179546_1_.func_71029_a(StatList.func_188057_b(this.field_151002_e));
++            // CM add meta
++            p_179546_1_.func_71029_a(StatList.getObjectUseStats(this.field_151002_e, this.field_77991_e));
+         }
+ 
+         return enumactionresult;
+@@ -207,7 +208,9 @@
  
      public int func_77976_d()
      {
@@ -11,7 +21,37 @@
      }
  
      public boolean func_77985_e()
-@@ -881,4 +883,9 @@
+@@ -334,7 +337,8 @@
+ 
+         if (flag)
+         {
+-            p_77961_2_.func_71029_a(StatList.func_188057_b(this.field_151002_e));
++            // CM add meta
++            p_77961_2_.func_71029_a(StatList.getObjectUseStats(this.field_151002_e, this.field_77991_e));
+         }
+     }
+ 
+@@ -344,7 +348,8 @@
+ 
+         if (flag)
+         {
+-            p_179548_4_.func_71029_a(StatList.func_188057_b(this.field_151002_e));
++            // CM add meta
++            p_179548_4_.func_71029_a(StatList.getObjectUseStats(this.field_151002_e, this.field_77991_e));
+         }
+     }
+ 
+@@ -496,7 +501,8 @@
+ 
+     public void func_77980_a(World p_77980_1_, EntityPlayer p_77980_2_, int p_77980_3_)
+     {
+-        p_77980_2_.func_71064_a(StatList.func_188060_a(this.field_151002_e), p_77980_3_);
++        // CM add meta
++        p_77980_2_.func_71064_a(StatList.getCraftStats(this.field_151002_e, this.field_77991_e), p_77980_3_);
+         this.func_77973_b().func_77622_d(this, p_77980_1_, p_77980_2_);
+     }
+ 
+@@ -881,4 +887,9 @@
      {
          this.func_190917_f(-p_190918_1_);
      }

--- a/patches/net/minecraft/item/ItemStack.java.patch
+++ b/patches/net/minecraft/item/ItemStack.java.patch
@@ -1,16 +1,25 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemStack.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemStack.java
-@@ -169,7 +169,8 @@
+@@ -41,6 +41,8 @@
+ import net.minecraft.util.text.translation.I18n;
+ import net.minecraft.world.World;
+ 
++import carpet.helpers.StatHelper;
++
+ public final class ItemStack
+ {
+     public static final ItemStack field_190927_a = new ItemStack((Item)null);
+@@ -169,7 +171,8 @@
  
          if (enumactionresult == EnumActionResult.SUCCESS)
          {
 -            p_179546_1_.func_71029_a(StatList.func_188057_b(this.field_151002_e));
 +            // CM add meta
-+            p_179546_1_.func_71029_a(StatList.getObjectUseStats(this.field_151002_e, this.field_77991_e));
++            p_179546_1_.func_71029_a(StatHelper.getObjectUseStats(this.field_151002_e, this.field_77991_e));
          }
  
          return enumactionresult;
-@@ -207,7 +208,9 @@
+@@ -207,7 +210,9 @@
  
      public int func_77976_d()
      {
@@ -21,37 +30,37 @@
      }
  
      public boolean func_77985_e()
-@@ -334,7 +337,8 @@
+@@ -334,7 +339,8 @@
  
          if (flag)
          {
 -            p_77961_2_.func_71029_a(StatList.func_188057_b(this.field_151002_e));
 +            // CM add meta
-+            p_77961_2_.func_71029_a(StatList.getObjectUseStats(this.field_151002_e, this.field_77991_e));
++            p_77961_2_.func_71029_a(StatHelper.getObjectUseStats(this.field_151002_e, this.field_77991_e));
          }
      }
  
-@@ -344,7 +348,8 @@
+@@ -344,7 +350,8 @@
  
          if (flag)
          {
 -            p_179548_4_.func_71029_a(StatList.func_188057_b(this.field_151002_e));
 +            // CM add meta
-+            p_179548_4_.func_71029_a(StatList.getObjectUseStats(this.field_151002_e, this.field_77991_e));
++            p_179548_4_.func_71029_a(StatHelper.getObjectUseStats(this.field_151002_e, this.field_77991_e));
          }
      }
  
-@@ -496,7 +501,8 @@
+@@ -496,7 +503,8 @@
  
      public void func_77980_a(World p_77980_1_, EntityPlayer p_77980_2_, int p_77980_3_)
      {
 -        p_77980_2_.func_71064_a(StatList.func_188060_a(this.field_151002_e), p_77980_3_);
 +        // CM add meta
-+        p_77980_2_.func_71064_a(StatList.getCraftStats(this.field_151002_e, this.field_77991_e), p_77980_3_);
++        p_77980_2_.func_71064_a(StatHelper.getCraftStats(this.field_151002_e, this.field_77991_e), p_77980_3_);
          this.func_77973_b().func_77622_d(this, p_77980_1_, p_77980_2_);
      }
  
-@@ -881,4 +887,9 @@
+@@ -881,4 +889,9 @@
      {
          this.func_190917_f(-p_190918_1_);
      }

--- a/patches/net/minecraft/scoreboard/ScoreCriteriaStat.java.patch
+++ b/patches/net/minecraft/scoreboard/ScoreCriteriaStat.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/scoreboard/ScoreCriteriaStat.java
++++ ../src-work/minecraft/net/minecraft/scoreboard/ScoreCriteriaStat.java
+@@ -4,7 +4,7 @@
+ 
+ public class ScoreCriteriaStat extends ScoreCriteria
+ {
+-    private final StatBase field_151459_g;
++    public final StatBase field_151459_g; // CM public
+ 
+     public ScoreCriteriaStat(StatBase p_i45483_1_)
+     {

--- a/patches/net/minecraft/stats/StatCrafting.java.patch
+++ b/patches/net/minecraft/stats/StatCrafting.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/stats/StatCrafting.java
++++ ../src-work/minecraft/net/minecraft/stats/StatCrafting.java
+@@ -5,7 +5,7 @@
+ 
+ public class StatCrafting extends StatBase
+ {
+-    private final Item field_150960_a;
++    public final Item field_150960_a; // CM public
+ 
+     public StatCrafting(String p_i45910_1_, String p_i45910_2_, ITextComponent p_i45910_3_, Item p_i45910_4_)
+     {

--- a/patches/net/minecraft/stats/StatList.java.patch
+++ b/patches/net/minecraft/stats/StatList.java.patch
@@ -1,0 +1,223 @@
+--- ../src-base/minecraft/net/minecraft/stats/StatList.java
++++ ../src-work/minecraft/net/minecraft/stats/StatList.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.stats;
+ 
++import carpet.helpers.StatSubItem;
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.Maps;
+ import com.google.common.collect.Sets;
+@@ -7,7 +8,11 @@
+ import java.util.Map;
+ import java.util.Set;
+ import javax.annotation.Nullable;
++
++import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
++import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+ import net.minecraft.block.Block;
++import net.minecraft.block.state.IBlockState;
+ import net.minecraft.entity.EntityList;
+ import net.minecraft.init.Blocks;
+ import net.minecraft.init.Items;
+@@ -17,7 +22,9 @@
+ import net.minecraft.item.crafting.CraftingManager;
+ import net.minecraft.item.crafting.FurnaceRecipes;
+ import net.minecraft.item.crafting.IRecipe;
++import net.minecraft.util.NonNullList;
+ import net.minecraft.util.ResourceLocation;
++import net.minecraft.util.text.ITextComponent;
+ import net.minecraft.util.text.TextComponentTranslation;
+ 
+ public class StatList
+@@ -83,20 +90,57 @@
+     private static final StatBase[] field_75930_F = new StatBase[32000];
+     private static final StatBase[] field_188067_ai = new StatBase[32000];
+     private static final StatBase[] field_188068_aj = new StatBase[32000];
++    // CM
++    private static final StatBase[] BLOCK_STATE_STATS = new StatBase[256 * 16];
++    private static final Int2ObjectMap<StatBase> CRAFT_META_STATS = new Int2ObjectOpenHashMap<>();
++    private static final Int2ObjectMap<StatBase> OBJECT_USE_META_STATS = new Int2ObjectOpenHashMap<>();
++    private static final Int2ObjectMap<StatBase> OBJECTS_PICKED_UP_META_STATS = new Int2ObjectOpenHashMap<>();
++    private static final Int2ObjectMap<StatBase> OBJECTS_DROPPED_META_STATS = new Int2ObjectOpenHashMap<>();
+ 
++    public static StatBase getBlockStateStats(IBlockState state) {
++        Block block = state.func_177230_c();
++        int id = Block.func_149682_b(block);
++        int meta = block.func_176201_c(state);
++        return BLOCK_STATE_STATS[(id << 4) | meta];
++    }
++
++    public static StatBase getCraftStats(Item item, int meta) {
++        int id = Item.func_150891_b(item);
++        return CRAFT_META_STATS.get((id << 4) | (meta & 0xf));
++    }
++
++    public static StatBase getObjectUseStats(Item item, int meta) {
++        int id = Item.func_150891_b(item);
++        return OBJECT_USE_META_STATS.get((id << 4) | (meta & 0xf));
++    }
++
++    public static StatBase getObjectsPickedUpStats(Item item, int meta) {
++        int id = Item.func_150891_b(item);
++        return OBJECTS_PICKED_UP_META_STATS.get((id << 4) | (meta & 0xf));
++    }
++
++    public static StatBase getDroppedObjectStats(Item item, int meta) {
++        int id = Item.func_150891_b(item);
++        return OBJECTS_DROPPED_META_STATS.get((id << 4) | (meta & 0xf));
++    }
++    // CM END
++
+     @Nullable
++    @Deprecated // CM
+     public static StatBase func_188055_a(Block p_188055_0_)
+     {
+         return field_188065_ae[Block.func_149682_b(p_188055_0_)];
+     }
+ 
+     @Nullable
++    @Deprecated // CM
+     public static StatBase func_188060_a(Item p_188060_0_)
+     {
+         return field_188066_af[Item.func_150891_b(p_188060_0_)];
+     }
+ 
+     @Nullable
++    @Deprecated // CM
+     public static StatBase func_188057_b(Item p_188057_0_)
+     {
+         return field_75929_E[Item.func_150891_b(p_188057_0_)];
+@@ -109,12 +153,14 @@
+     }
+ 
+     @Nullable
++    @Deprecated // CM
+     public static StatBase func_188056_d(Item p_188056_0_)
+     {
+         return field_188067_ai[Item.func_150891_b(p_188056_0_)];
+     }
+ 
+     @Nullable
++    @Deprecated // CM
+     public static StatBase func_188058_e(Item p_188058_0_)
+     {
+         return field_188068_aj[Item.func_150891_b(p_188058_0_)];
+@@ -157,7 +203,24 @@
+ 
+                 if (s != null)
+                 {
+-                    field_188066_af[i] = (new StatCrafting("stat.craftItem.", s, new TextComponentTranslation("stat.craftItem", new Object[] {(new ItemStack(item)).func_151000_E()}), item)).func_75971_g();
++                    // CM
++                    StatCrafting baseStat = (StatCrafting) new StatCrafting("stat.craftItem.", s, new TextComponentTranslation("stat.craftItem", new ItemStack(item).func_151000_E()), item).func_75971_g();
++                    field_188066_af[i] = baseStat;
++                    if (item.func_77614_k()) {
++                        for (int meta = 0; meta < 16; meta++) {
++                            int stateId = (i << 4) | meta;
++                            ItemStack stackWithMeta = new ItemStack(item, 1, meta);
++                            ITextComponent text = new TextComponentTranslation("stat.craftItem", stackWithMeta.func_151000_E());
++                            StatSubItem statWithMeta = (StatSubItem) new StatSubItem(baseStat, meta, text).func_75971_g();
++                            CRAFT_META_STATS.put(stateId, statWithMeta);
++                        }
++                    } else {
++                        for (int meta = 0; meta < 16; meta++) {
++                            int stateId = (i << 4) | meta;
++                            CRAFT_META_STATS.put(stateId, baseStat);
++                        }
++                    }
++                    // CM END
+                 }
+             }
+         }
+@@ -178,8 +241,27 @@
+ 
+                 if (s != null && block.func_149652_G())
+                 {
+-                    field_188065_ae[i] = (new StatCrafting("stat.mineBlock.", s, new TextComponentTranslation("stat.mineBlock", new Object[] {(new ItemStack(block)).func_151000_E()}), item)).func_75971_g();
++                    // CM
++                    ITextComponent baseText = new TextComponentTranslation("stat.mineBlock", new ItemStack(block).func_151000_E());
++                    StatCrafting baseStat = (StatCrafting) new StatCrafting("stat.mineBlock.", s, baseText, item).func_75971_g();
++                    field_188065_ae[i] = baseStat;
+                     field_188096_e.add((StatCrafting)field_188065_ae[i]);
++                    if (item.func_77614_k()) {
++                        for (int meta = 0; meta < 16; meta++) {
++                            int stateId = (i << 4) | meta;
++                            ItemStack stackWithMeta = new ItemStack(block, 1, meta);
++                            ITextComponent text = new TextComponentTranslation("stat.mineBlock", stackWithMeta.func_151000_E());
++                            StatSubItem statWithMeta = (StatSubItem) new StatSubItem(baseStat, meta, text).func_75971_g();
++                            BLOCK_STATE_STATS[stateId] = statWithMeta;
++                            field_188096_e.add(statWithMeta);
++                        }
++                    } else {
++                        for (int meta = 0; meta < 16; meta++) {
++                            int stateId = (i << 4) | meta;
++                            BLOCK_STATE_STATS[stateId] = baseStat;
++                        }
++                    }
++                    // CM END
+                 }
+             }
+         }
+@@ -198,12 +280,25 @@
+ 
+                 if (s != null)
+                 {
+-                    field_75929_E[i] = (new StatCrafting("stat.useItem.", s, new TextComponentTranslation("stat.useItem", new Object[] {(new ItemStack(item)).func_151000_E()}), item)).func_75971_g();
+-
+-                    if (!(item instanceof ItemBlock))
+-                    {
+-                        field_188095_d.add((StatCrafting)field_75929_E[i]);
++                    // CM
++                    StatCrafting baseStat = (StatCrafting) new StatCrafting("stat.useItem.", s, new TextComponentTranslation("stat.useItem", new ItemStack(item).func_151000_E()), item).func_75971_g();
++                    field_75929_E[i] = baseStat;
++                    if (!(item instanceof ItemBlock)) field_188095_d.add((StatCrafting)field_75929_E[i]);
++                    if (item.func_77614_k()) {
++                        for (int meta = 0; meta < 16; meta++) {
++                            int stateId = (i << 4) | meta;
++                            ItemStack stackWithMeta = new ItemStack(item, 1, meta);
++                            ITextComponent text = new TextComponentTranslation("stat.useItem", stackWithMeta.func_151000_E());
++                            StatSubItem statWithMeta = (StatSubItem) new StatSubItem(baseStat, meta, text).func_75971_g();
++                            OBJECT_USE_META_STATS.put(stateId, statWithMeta);
++                        }
++                    } else {
++                        for (int meta = 0; meta < 16; meta++) {
++                            int stateId = (i << 4) | meta;
++                            OBJECT_USE_META_STATS.put(stateId, baseStat);
++                        }
+                     }
++                    // CM END
+                 }
+             }
+         }
+@@ -241,8 +336,30 @@
+ 
+                 if (s != null)
+                 {
+-                    field_188067_ai[i] = (new StatCrafting("stat.pickup.", s, new TextComponentTranslation("stat.pickup", new Object[] {(new ItemStack(item)).func_151000_E()}), item)).func_75971_g();
+-                    field_188068_aj[i] = (new StatCrafting("stat.drop.", s, new TextComponentTranslation("stat.drop", new Object[] {(new ItemStack(item)).func_151000_E()}), item)).func_75971_g();
++                    // CM
++                    StatCrafting basePickupStat = (StatCrafting) new StatCrafting("stat.pickup.", s, new TextComponentTranslation("stat.pickup", new ItemStack(item).func_151000_E()), item).func_75971_g();
++                    field_188067_ai[i] = basePickupStat;
++                    StatCrafting baseDropStat = (StatCrafting) new StatCrafting("stat.drop.", s, new TextComponentTranslation("stat.drop", new ItemStack(item).func_151000_E()), item).func_75971_g();
++                    field_188068_aj[i] = baseDropStat;
++                    if (item.func_77614_k()) {
++                        for (int meta = 0; meta < 16; meta++) {
++                            int stateId = (i << 4) | meta;
++                            ItemStack stackWithMeta = new ItemStack(item, 1, meta);
++                            ITextComponent textPickup = new TextComponentTranslation("stat.pickup", stackWithMeta.func_151000_E());
++                            StatSubItem pickupWithMeta = (StatSubItem) new StatSubItem(basePickupStat, meta, textPickup).func_75971_g();
++                            OBJECTS_PICKED_UP_META_STATS.put(stateId, pickupWithMeta);
++                            ITextComponent textDrop = new TextComponentTranslation("stat.drop", stackWithMeta.func_151000_E());
++                            StatSubItem dropWithMeta = (StatSubItem) new StatSubItem(baseDropStat, meta, textDrop).func_75971_g();
++                            OBJECTS_DROPPED_META_STATS.put(stateId, dropWithMeta);
++                        }
++                    } else {
++                        for (int meta = 0; meta < 16; meta++) {
++                            int stateId = (i << 4) | meta;
++                            OBJECTS_PICKED_UP_META_STATS.put(stateId, basePickupStat);
++                            OBJECTS_DROPPED_META_STATS.put(stateId, baseDropStat);
++                        }
++                    }
++                    // CM END
+                 }
+             }
+         }

--- a/patches/net/minecraft/stats/StatList.java.patch
+++ b/patches/net/minecraft/stats/StatList.java.patch
@@ -1,73 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/stats/StatList.java
 +++ ../src-work/minecraft/net/minecraft/stats/StatList.java
-@@ -1,5 +1,6 @@
- package net.minecraft.stats;
- 
-+import carpet.helpers.StatSubItem;
- import com.google.common.collect.Lists;
- import com.google.common.collect.Maps;
- import com.google.common.collect.Sets;
-@@ -7,7 +8,11 @@
- import java.util.Map;
- import java.util.Set;
- import javax.annotation.Nullable;
-+
-+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
- import net.minecraft.block.Block;
-+import net.minecraft.block.state.IBlockState;
- import net.minecraft.entity.EntityList;
- import net.minecraft.init.Blocks;
- import net.minecraft.init.Items;
-@@ -17,7 +22,9 @@
- import net.minecraft.item.crafting.CraftingManager;
- import net.minecraft.item.crafting.FurnaceRecipes;
+@@ -19,6 +19,7 @@
  import net.minecraft.item.crafting.IRecipe;
-+import net.minecraft.util.NonNullList;
  import net.minecraft.util.ResourceLocation;
-+import net.minecraft.util.text.ITextComponent;
  import net.minecraft.util.text.TextComponentTranslation;
++import carpet.helpers.StatHelper;
  
  public class StatList
-@@ -83,20 +90,57 @@
-     private static final StatBase[] field_75930_F = new StatBase[32000];
-     private static final StatBase[] field_188067_ai = new StatBase[32000];
+ {
+@@ -85,18 +86,21 @@
      private static final StatBase[] field_188068_aj = new StatBase[32000];
-+    // CM
-+    private static final StatBase[] BLOCK_STATE_STATS = new StatBase[256 * 16];
-+    private static final Int2ObjectMap<StatBase> CRAFT_META_STATS = new Int2ObjectOpenHashMap<>();
-+    private static final Int2ObjectMap<StatBase> OBJECT_USE_META_STATS = new Int2ObjectOpenHashMap<>();
-+    private static final Int2ObjectMap<StatBase> OBJECTS_PICKED_UP_META_STATS = new Int2ObjectOpenHashMap<>();
-+    private static final Int2ObjectMap<StatBase> OBJECTS_DROPPED_META_STATS = new Int2ObjectOpenHashMap<>();
  
-+    public static StatBase getBlockStateStats(IBlockState state) {
-+        Block block = state.func_177230_c();
-+        int id = Block.func_149682_b(block);
-+        int meta = block.func_176201_c(state);
-+        return BLOCK_STATE_STATS[(id << 4) | meta];
-+    }
-+
-+    public static StatBase getCraftStats(Item item, int meta) {
-+        int id = Item.func_150891_b(item);
-+        return CRAFT_META_STATS.get((id << 4) | (meta & 0xf));
-+    }
-+
-+    public static StatBase getObjectUseStats(Item item, int meta) {
-+        int id = Item.func_150891_b(item);
-+        return OBJECT_USE_META_STATS.get((id << 4) | (meta & 0xf));
-+    }
-+
-+    public static StatBase getObjectsPickedUpStats(Item item, int meta) {
-+        int id = Item.func_150891_b(item);
-+        return OBJECTS_PICKED_UP_META_STATS.get((id << 4) | (meta & 0xf));
-+    }
-+
-+    public static StatBase getDroppedObjectStats(Item item, int meta) {
-+        int id = Item.func_150891_b(item);
-+        return OBJECTS_DROPPED_META_STATS.get((id << 4) | (meta & 0xf));
-+    }
-+    // CM END
-+
      @Nullable
 +    @Deprecated // CM
      public static StatBase func_188055_a(Block p_188055_0_)
@@ -87,7 +30,7 @@
      public static StatBase func_188057_b(Item p_188057_0_)
      {
          return field_75929_E[Item.func_150891_b(p_188057_0_)];
-@@ -109,12 +153,14 @@
+@@ -109,12 +113,14 @@
      }
  
      @Nullable
@@ -102,7 +45,7 @@
      public static StatBase func_188058_e(Item p_188058_0_)
      {
          return field_188068_aj[Item.func_150891_b(p_188058_0_)];
-@@ -157,7 +203,24 @@
+@@ -157,7 +163,11 @@
  
                  if (s != null)
                  {
@@ -110,54 +53,26 @@
 +                    // CM
 +                    StatCrafting baseStat = (StatCrafting) new StatCrafting("stat.craftItem.", s, new TextComponentTranslation("stat.craftItem", new ItemStack(item).func_151000_E()), item).func_75971_g();
 +                    field_188066_af[i] = baseStat;
-+                    if (item.func_77614_k()) {
-+                        for (int meta = 0; meta < 16; meta++) {
-+                            int stateId = (i << 4) | meta;
-+                            ItemStack stackWithMeta = new ItemStack(item, 1, meta);
-+                            ITextComponent text = new TextComponentTranslation("stat.craftItem", stackWithMeta.func_151000_E());
-+                            StatSubItem statWithMeta = (StatSubItem) new StatSubItem(baseStat, meta, text).func_75971_g();
-+                            CRAFT_META_STATS.put(stateId, statWithMeta);
-+                        }
-+                    } else {
-+                        for (int meta = 0; meta < 16; meta++) {
-+                            int stateId = (i << 4) | meta;
-+                            CRAFT_META_STATS.put(stateId, baseStat);
-+                        }
-+                    }
++                    StatHelper.addCraftStats(item, baseStat);
 +                    // CM END
                  }
              }
          }
-@@ -178,8 +241,27 @@
+@@ -178,8 +188,12 @@
  
                  if (s != null && block.func_149652_G())
                  {
 -                    field_188065_ae[i] = (new StatCrafting("stat.mineBlock.", s, new TextComponentTranslation("stat.mineBlock", new Object[] {(new ItemStack(block)).func_151000_E()}), item)).func_75971_g();
 +                    // CM
-+                    ITextComponent baseText = new TextComponentTranslation("stat.mineBlock", new ItemStack(block).func_151000_E());
-+                    StatCrafting baseStat = (StatCrafting) new StatCrafting("stat.mineBlock.", s, baseText, item).func_75971_g();
++                    StatCrafting baseStat = (StatCrafting) new StatCrafting("stat.mineBlock.", s, new TextComponentTranslation("stat.mineBlock", new ItemStack(block).func_151000_E()), item).func_75971_g();
 +                    field_188065_ae[i] = baseStat;
                      field_188096_e.add((StatCrafting)field_188065_ae[i]);
-+                    if (item.func_77614_k()) {
-+                        for (int meta = 0; meta < 16; meta++) {
-+                            int stateId = (i << 4) | meta;
-+                            ItemStack stackWithMeta = new ItemStack(block, 1, meta);
-+                            ITextComponent text = new TextComponentTranslation("stat.mineBlock", stackWithMeta.func_151000_E());
-+                            StatSubItem statWithMeta = (StatSubItem) new StatSubItem(baseStat, meta, text).func_75971_g();
-+                            BLOCK_STATE_STATS[stateId] = statWithMeta;
-+                            field_188096_e.add(statWithMeta);
-+                        }
-+                    } else {
-+                        for (int meta = 0; meta < 16; meta++) {
-+                            int stateId = (i << 4) | meta;
-+                            BLOCK_STATE_STATS[stateId] = baseStat;
-+                        }
-+                    }
++                    StatHelper.addMineStats(block, baseStat);
 +                    // CM END
                  }
              }
          }
-@@ -198,12 +280,25 @@
+@@ -198,12 +212,12 @@
  
                  if (s != null)
                  {
@@ -166,29 +81,17 @@
 -                    if (!(item instanceof ItemBlock))
 -                    {
 -                        field_188095_d.add((StatCrafting)field_75929_E[i]);
+-                    }
 +                    // CM
 +                    StatCrafting baseStat = (StatCrafting) new StatCrafting("stat.useItem.", s, new TextComponentTranslation("stat.useItem", new ItemStack(item).func_151000_E()), item).func_75971_g();
 +                    field_75929_E[i] = baseStat;
 +                    if (!(item instanceof ItemBlock)) field_188095_d.add((StatCrafting)field_75929_E[i]);
-+                    if (item.func_77614_k()) {
-+                        for (int meta = 0; meta < 16; meta++) {
-+                            int stateId = (i << 4) | meta;
-+                            ItemStack stackWithMeta = new ItemStack(item, 1, meta);
-+                            ITextComponent text = new TextComponentTranslation("stat.useItem", stackWithMeta.func_151000_E());
-+                            StatSubItem statWithMeta = (StatSubItem) new StatSubItem(baseStat, meta, text).func_75971_g();
-+                            OBJECT_USE_META_STATS.put(stateId, statWithMeta);
-+                        }
-+                    } else {
-+                        for (int meta = 0; meta < 16; meta++) {
-+                            int stateId = (i << 4) | meta;
-+                            OBJECT_USE_META_STATS.put(stateId, baseStat);
-+                        }
-                     }
++                    StatHelper.addUseStats(item, baseStat);
 +                    // CM END
                  }
              }
          }
-@@ -241,8 +336,30 @@
+@@ -241,8 +255,13 @@
  
                  if (s != null)
                  {
@@ -199,24 +102,7 @@
 +                    field_188067_ai[i] = basePickupStat;
 +                    StatCrafting baseDropStat = (StatCrafting) new StatCrafting("stat.drop.", s, new TextComponentTranslation("stat.drop", new ItemStack(item).func_151000_E()), item).func_75971_g();
 +                    field_188068_aj[i] = baseDropStat;
-+                    if (item.func_77614_k()) {
-+                        for (int meta = 0; meta < 16; meta++) {
-+                            int stateId = (i << 4) | meta;
-+                            ItemStack stackWithMeta = new ItemStack(item, 1, meta);
-+                            ITextComponent textPickup = new TextComponentTranslation("stat.pickup", stackWithMeta.func_151000_E());
-+                            StatSubItem pickupWithMeta = (StatSubItem) new StatSubItem(basePickupStat, meta, textPickup).func_75971_g();
-+                            OBJECTS_PICKED_UP_META_STATS.put(stateId, pickupWithMeta);
-+                            ITextComponent textDrop = new TextComponentTranslation("stat.drop", stackWithMeta.func_151000_E());
-+                            StatSubItem dropWithMeta = (StatSubItem) new StatSubItem(baseDropStat, meta, textDrop).func_75971_g();
-+                            OBJECTS_DROPPED_META_STATS.put(stateId, dropWithMeta);
-+                        }
-+                    } else {
-+                        for (int meta = 0; meta < 16; meta++) {
-+                            int stateId = (i << 4) | meta;
-+                            OBJECTS_PICKED_UP_META_STATS.put(stateId, basePickupStat);
-+                            OBJECTS_DROPPED_META_STATS.put(stateId, baseDropStat);
-+                        }
-+                    }
++                    StatHelper.addPickedUpAndDroppedStats(item, basePickupStat, baseDropStat);
 +                    // CM END
                  }
              }

--- a/patches/net/minecraft/stats/StatisticsManager.java.patch
+++ b/patches/net/minecraft/stats/StatisticsManager.java.patch
@@ -1,0 +1,21 @@
+--- ../src-base/minecraft/net/minecraft/stats/StatisticsManager.java
++++ ../src-work/minecraft/net/minecraft/stats/StatisticsManager.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.stats;
+ 
++import carpet.helpers.StatSubItem;
+ import com.google.common.collect.Maps;
+ import java.util.Map;
+ import net.minecraft.entity.player.EntityPlayer;
+@@ -12,6 +13,11 @@
+     public void func_150871_b(EntityPlayer p_150871_1_, StatBase p_150871_2_, int p_150871_3_)
+     {
+         this.func_150873_a(p_150871_1_, p_150871_2_, this.func_77444_a(p_150871_2_) + p_150871_3_);
++        // CM
++        if (p_150871_2_ instanceof StatSubItem) {
++            this.func_150871_b(p_150871_1_, ((StatSubItem) p_150871_2_).getBase(), p_150871_3_);
++        }
++        // CM END
+     }
+ 
+     public void func_150873_a(EntityPlayer p_150873_1_, StatBase p_150873_2_, int p_150873_3_)


### PR DESCRIPTION
Adds statistics for sub-items (for example `stat.mineBlock.minecraft.concrete.4`) that are also summed up to (tracked in parallel with) the base stat (`stat.mineBlock.minecraft.concrete`) for vanilla compatibility since those new stats are not displayed in the client's statistics GUI.

Since unknown statistics are just ignored by the client they can be sent to all clients; so a future Carpet Client version can add them to the client's `StatList` to display them.

`/scoreboard objectives add` now initializes to the statistic values if the objective is tracking a statistic.