### PR TITLE
Add customizable tile tick limit

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -282,7 +282,7 @@ public class CarpetSettings
   rule("disablePlayerCollision","creative", "Disables player entity collision."),
   rule("randomTickOptimization","fix", "Stops blocks which don't need to be random ticked from being random ticked")
                                 .extraInfo("Fixed in 1.13"),
-  rule("tileTickLimit",         "fix", "Customizable tile tick limit")
+  rule("tileTickLimit",         "survival", "Customizable tile tick limit")
                                 .choices("65536","1000 65536 1000000").setNotStrict(),
         };
         for (CarpetSettingEntry rule: RuleList)

--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -88,6 +88,7 @@ public class CarpetSettings
     public static boolean endRNG = false;
     public static int structureBlockLimit = 32;
     public static boolean disablePlayerCollision = false;
+    public static int tileTickLimit = 65536;
 
     public static long setSeed = 0;
 
@@ -281,7 +282,8 @@ public class CarpetSettings
   rule("disablePlayerCollision","creative", "Disables player entity collision."),
   rule("randomTickOptimization","fix", "Stops blocks which don't need to be random ticked from being random ticked")
                                 .extraInfo("Fixed in 1.13"),
-
+  rule("tileTickLimit",         "fix", "Customizable tile tick limit")
+                                .choices("65536","1000 65536 1000000").setNotStrict(),
         };
         for (CarpetSettingEntry rule: RuleList)
         {
@@ -324,6 +326,7 @@ public class CarpetSettings
         endRNG = CarpetSettings.getBool("endRNG");
         structureBlockLimit = CarpetSettings.getInt("structureBlockLimit");
         disablePlayerCollision = CarpetSettings.getBool("disablePlayerCollision");
+        tileTickLimit = CarpetSettings.getInt("tileTickLimit");
 
         if ("pistonGhostBlocksFix".equalsIgnoreCase(rule))
         {

--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -283,6 +283,7 @@ public class CarpetSettings
   rule("randomTickOptimization","fix", "Stops blocks which don't need to be random ticked from being random ticked")
                                 .extraInfo("Fixed in 1.13"),
   rule("tileTickLimit",         "survival", "Customizable tile tick limit")
+                                .extraInfo("Negative for no limit")
                                 .choices("65536","1000 65536 1000000").setNotStrict(),
         };
         for (CarpetSettingEntry rule: RuleList)

--- a/carpetmodSrc/carpet/logging/LoggerRegistry.java
+++ b/carpetmodSrc/carpet/logging/LoggerRegistry.java
@@ -28,6 +28,7 @@ public class LoggerRegistry
     public static boolean __damage;
     public static boolean __packets;
     public static boolean __weather;
+    public static boolean __tileTickLimit;
 
     public static void initLoggers(MinecraftServer server)
     {
@@ -37,6 +38,7 @@ public class LoggerRegistry
         registerLogger("kills", new Logger(server, "kills", null, null, LogHandler.CHAT));
         registerLogger("damage", new Logger(server, "damage", "all", new String[]{"all","players","me"}, LogHandler.CHAT));
         registerLogger("weather", new Logger(server, "weather", null, null, LogHandler.CHAT));
+        registerLogger("tileTickLimit", new Logger(server, "tileTickLimit", null, null, LogHandler.CHAT));
 
         registerLogger("tps", new Logger(server, "tps", null, null, LogHandler.HUD));
         registerLogger("packets", new Logger(server, "packets", null, null, LogHandler.HUD));

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -209,7 +209,7 @@
              {
 -                if (i > 65536)
 +                int tileTickLimit = CarpetSettings.tileTickLimit;
-+                if (i > tileTickLimit)
++                if (tileTickLimit >= 0 && i > tileTickLimit)
                  {
 -                    i = 65536;
 +                    if (LoggerRegistry.__tileTickLimit) {

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/world/WorldServer.java
 +++ ../src-work/minecraft/net/minecraft/world/WorldServer.java
-@@ -79,12 +79,17 @@
+@@ -1,5 +1,7 @@
+ package net.minecraft.world;
+ 
++import carpet.logging.LoggerRegistry;
++import carpet.utils.Messenger;
+ import com.google.common.base.Predicate;
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.Maps;
+@@ -59,6 +61,7 @@
+ import net.minecraft.util.math.ChunkPos;
+ import net.minecraft.util.math.MathHelper;
+ import net.minecraft.util.math.Vec3d;
++import net.minecraft.util.text.ITextComponent;
+ import net.minecraft.village.VillageCollection;
+ import net.minecraft.village.VillageSiege;
+ import net.minecraft.world.biome.Biome;
+@@ -79,12 +82,17 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
@@ -19,7 +35,7 @@
      private final Set<NextTickListEntry> field_73064_N = Sets.<NextTickListEntry>newHashSet();
      private final TreeSet<NextTickListEntry> field_73065_O = new TreeSet<NextTickListEntry>();
      private final Map<UUID, Entity> field_175741_N = Maps.<UUID, Entity>newHashMap();
-@@ -183,12 +188,19 @@
+@@ -183,12 +191,19 @@
              this.func_73053_d();
          }
  
@@ -39,7 +55,7 @@
  
          this.field_72984_F.func_76318_c("chunkSource");
          this.field_73020_y.func_73156_b();
-@@ -199,26 +211,56 @@
+@@ -199,26 +214,56 @@
              this.func_175692_b(j);
          }
  
@@ -98,7 +114,7 @@
      }
  
      @Nullable
-@@ -254,8 +296,15 @@
+@@ -254,8 +299,15 @@
                      ++j;
                  }
              }
@@ -116,7 +132,7 @@
          }
      }
  
-@@ -289,6 +338,28 @@
+@@ -289,6 +341,28 @@
      {
          if (this.field_73068_P && !this.field_72995_K)
          {
@@ -145,7 +161,7 @@
              for (EntityPlayer entityplayer : this.field_73010_i)
              {
                  if (!entityplayer.func_175149_v() && !entityplayer.func_71026_bH())
-@@ -305,7 +376,7 @@
+@@ -305,7 +379,7 @@
          }
      }
  
@@ -154,7 +170,7 @@
      {
          return this.func_72863_F().func_73149_a(p_175680_1_, p_175680_2_);
      }
-@@ -357,6 +428,11 @@
+@@ -357,6 +431,11 @@
                  chunk.func_76594_o();
                  this.field_72984_F.func_76318_c("tickChunk");
                  chunk.func_150804_b(false);
@@ -166,7 +182,7 @@
                  this.field_72984_F.func_76318_c("thunder");
  
                  if (flag && flag1 && this.field_73012_v.nextInt(100000) == 0)
-@@ -445,7 +521,7 @@
+@@ -445,7 +524,7 @@
          }
      }
  
@@ -175,7 +191,7 @@
      {
          BlockPos blockpos = this.func_175725_q(p_175736_1_);
          AxisAlignedBB axisalignedbb = (new AxisAlignedBB(blockpos, new BlockPos(blockpos.func_177958_n(), this.func_72800_K(), blockpos.func_177952_p()))).func_186662_g(3.0D);
-@@ -505,9 +581,10 @@
+@@ -505,9 +584,10 @@
                      {
                          iblockstate.func_177230_c().func_180650_b(this, p_175654_1_, iblockstate, this.field_73012_v);
                      }
@@ -187,7 +203,7 @@
              }
  
              p_175654_3_ = 1;
-@@ -646,9 +723,11 @@
+@@ -646,9 +726,18 @@
              }
              else
              {
@@ -196,12 +212,19 @@
 +                if (i > tileTickLimit)
                  {
 -                    i = 65536;
-+                    field_147491_a.warn(String.format("Reached tile tick limit (%d > %d)", i, tileTickLimit));
++                    if (LoggerRegistry.__tileTickLimit) {
++                        final int fi = i;
++                        LoggerRegistry.getLogger("tileTickLimit").log(() -> new ITextComponent[] {
++                            Messenger.s(null, String.format("Reached tile tick limit (%d > %d)", fi, tileTickLimit))
++                        },
++                        "NUMBER", i,
++                        "LIMIT", tileTickLimit);
++                    }
 +                    i = tileTickLimit;
                  }
  
                  this.field_72984_F.func_76320_a("cleaning");
-@@ -1057,6 +1136,7 @@
+@@ -1057,6 +1146,7 @@
          this.field_175729_l.func_76038_a(p_72923_1_.func_145782_y(), p_72923_1_);
          this.field_175741_N.put(p_72923_1_.func_110124_au(), p_72923_1_);
          Entity[] aentity = p_72923_1_.func_70021_al();

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -187,7 +187,21 @@
              }
  
              p_175654_3_ = 1;
-@@ -1057,6 +1134,7 @@
+@@ -646,9 +723,11 @@
+             }
+             else
+             {
+-                if (i > 65536)
++                int tileTickLimit = CarpetSettings.tileTickLimit;
++                if (i > tileTickLimit)
+                 {
+-                    i = 65536;
++                    field_147491_a.warn(String.format("Reached tile tick limit (%d > %d)", i, tileTickLimit));
++                    i = tileTickLimit;
+                 }
+ 
+                 this.field_72984_F.func_76320_a("cleaning");
+@@ -1057,6 +1136,7 @@
          this.field_175729_l.func_76038_a(p_72923_1_.func_145782_y(), p_72923_1_);
          this.field_175741_N.put(p_72923_1_.func_110124_au(), p_72923_1_);
          Entity[] aentity = p_72923_1_.func_70021_al();


### PR DESCRIPTION
Makes the tile tick limit customizable via the `tileTickLimit` carpetrule.
Also logs a warning when the limit is exceeded.

Is "fix" the proper category for this?