### PR TITLE
Disable vanilla tick warp "feature" (by Xcom)

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -89,6 +89,7 @@ public class CarpetSettings
     public static int structureBlockLimit = 32;
     public static boolean disablePlayerCollision = false;
     public static int tileTickLimit = 65536;
+    public static boolean disableVanillaTickWarp = false;
 
     public static long setSeed = 0;
 
@@ -285,6 +286,7 @@ public class CarpetSettings
   rule("tileTickLimit",         "survival", "Customizable tile tick limit")
                                 .extraInfo("Negative for no limit")
                                 .choices("65536","1000 65536 1000000").setNotStrict(),
+  rule("disableVanillaTickWarp", "fix", "Disables the catching-up behavior after lag spikes"),
         };
         for (CarpetSettingEntry rule: RuleList)
         {
@@ -328,6 +330,7 @@ public class CarpetSettings
         structureBlockLimit = CarpetSettings.getInt("structureBlockLimit");
         disablePlayerCollision = CarpetSettings.getBool("disablePlayerCollision");
         tileTickLimit = CarpetSettings.getInt("tileTickLimit");
+        disableVanillaTickWarp = CarpetSettings.getBool("disableVanillaTickWarp");
 
         if ("pistonGhostBlocksFix".equalsIgnoreCase(rule))
         {
@@ -726,6 +729,7 @@ public class CarpetSettings
         set("reloadUpdateOrderFix","true");
         set("leashFix","true");
         set("randomTickOptimization","true");
+        set("disableVanillaTickWarp","true");
     }
 
     public static class CarpetSettingEntry 

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -111,7 +111,7 @@
  
                      if (this.field_71305_c[0].func_73056_e())
                      {
-@@ -481,14 +513,29 @@
+@@ -481,14 +513,30 @@
                      }
                      else
                      {
@@ -129,6 +129,7 @@
 +                            }
                              this.func_71217_p();
 +                            keeping_up = true;
++                            if (CarpetSettings.disableVanillaTickWarp) break;
                          }
                      }
  
@@ -144,7 +145,7 @@
                      this.field_71296_Q = true;
                  }
              }
-@@ -592,6 +639,11 @@
+@@ -592,6 +640,11 @@
      {
          long i = System.nanoTime();
          ++this.field_71315_w;
@@ -156,7 +157,7 @@
  
          if (this.field_71295_T)
          {
-@@ -621,12 +673,17 @@
+@@ -621,12 +674,17 @@
  
          if (this.field_71315_w % 900 == 0)
          {
@@ -174,7 +175,7 @@
          this.field_71304_b.func_76320_a("tallying");
          this.field_71311_j[this.field_71315_w % 100] = System.nanoTime() - i;
          this.field_71304_b.func_76319_b();
-@@ -644,6 +701,10 @@
+@@ -644,6 +702,10 @@
  
          this.field_71304_b.func_76319_b();
          this.field_71304_b.func_76319_b();
@@ -185,7 +186,7 @@
      }
  
      public void func_71190_q()
-@@ -710,10 +771,12 @@
+@@ -710,10 +772,12 @@
              this.field_71312_k[j][this.field_71315_w % 100] = System.nanoTime() - i;
          }
  


### PR DESCRIPTION
Adds an option to disable the vanilla tick warp that happens after lag spikes