### PR TITLE
Entity dismount fix (by Xcom)

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -89,6 +89,7 @@ public class CarpetSettings
     public static int structureBlockLimit = 32;
     public static boolean disablePlayerCollision = false;
     public static int tileTickLimit = 65536;
+    public static boolean dismountFix = false;
 
     public static long setSeed = 0;
 
@@ -285,6 +286,7 @@ public class CarpetSettings
   rule("tileTickLimit",         "survival", "Customizable tile tick limit")
                                 .extraInfo("Negative for no limit")
                                 .choices("65536","1000 65536 1000000").setNotStrict(),
+  rule("dismountFix",           "fix", "Fix dismount behavior that leads to ghost chicken jockeys")
         };
         for (CarpetSettingEntry rule: RuleList)
         {
@@ -328,6 +330,7 @@ public class CarpetSettings
         structureBlockLimit = CarpetSettings.getInt("structureBlockLimit");
         disablePlayerCollision = CarpetSettings.getBool("disablePlayerCollision");
         tileTickLimit = CarpetSettings.getInt("tileTickLimit");
+        dismountFix = CarpetSettings.getBool("dismountFix");
 
         if ("pistonGhostBlocksFix".equalsIgnoreCase(rule))
         {
@@ -726,6 +729,7 @@ public class CarpetSettings
         set("reloadUpdateOrderFix","true");
         set("leashFix","true");
         set("randomTickOptimization","true");
+        set("dismountFix","true");
     }
 
     public static class CarpetSettingEntry 

--- a/patches/net/minecraft/entity/Entity.java.patch
+++ b/patches/net/minecraft/entity/Entity.java.patch
@@ -118,7 +118,26 @@
      }
  
      public boolean func_184220_m(Entity p_184220_1_)
-@@ -2578,6 +2621,10 @@
+@@ -1966,6 +2009,18 @@
+         }
+     }
+ 
++    // CM
++    public final void dismountRidingEntityBase()
++    {
++        if (this.field_184239_as != null)
++        {
++            Entity entity = this.field_184239_as;
++            this.field_184239_as = null;
++            entity.func_184225_p(this);
++        }
++    }
++    // CM END
++
+     protected void func_184200_o(Entity p_184200_1_)
+     {
+         if (p_184200_1_.func_184187_bx() != this)
+@@ -2578,6 +2633,10 @@
  
      public EnumFacing func_174811_aO()
      {
@@ -129,7 +148,7 @@
          return EnumFacing.func_176731_b(MathHelper.func_76128_c((double)(this.field_70177_z * 4.0F / 360.0F) + 0.5D) & 3);
      }
  
-@@ -2886,4 +2933,14 @@
+@@ -2886,4 +2945,14 @@
      {
          return 1;
      }

--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -319,7 +319,20 @@
              {
                  p_72866_1_.field_70175_ag = false;
              }
-@@ -1685,7 +1823,8 @@
+@@ -1666,7 +1804,11 @@
+                 }
+                 else
+                 {
+-                    entity.func_184210_p();
++                    if (CarpetSettings.dismountFix) {
++                        entity.dismountRidingEntityBase();
++                    } else {
++                        entity.func_184210_p();
++                    }
+                 }
+             }
+         }
+@@ -1685,7 +1827,8 @@
          {
              Entity entity = list.get(i);
  
@@ -329,7 +342,7 @@
              {
                  return false;
              }
-@@ -2149,6 +2288,16 @@
+@@ -2149,6 +2292,16 @@
                          {
                              this.field_72986_A.func_76090_f(this.field_73012_v.nextInt(168000) + 12000);
                          }
@@ -346,7 +359,7 @@
                      }
                      else
                      {
-@@ -2173,6 +2322,16 @@
+@@ -2173,6 +2326,16 @@
                          {
                              this.field_72986_A.func_76080_g(this.field_73012_v.nextInt(168000) + 12000);
                          }
@@ -363,7 +376,7 @@
                      }
                      else
                      {
-@@ -2383,6 +2542,11 @@
+@@ -2383,6 +2546,11 @@
  
      public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
      {
@@ -375,7 +388,7 @@
          if (!this.func_175648_a(p_180500_2_, 17, false))
          {
              return false;
-@@ -3263,30 +3427,44 @@
+@@ -3263,30 +3431,44 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -432,7 +445,7 @@
      }
  
      public DifficultyInstance func_175649_E(BlockPos p_175649_1_)
-@@ -3357,4 +3535,17 @@
+@@ -3357,4 +3539,17 @@
      {
          return null;
      }


### PR DESCRIPTION
Fixes dismounting for riders of dead entities by skipping the `EntityLivingBase::dismountEntity(Entity)` collision checks, etc. and falling back to the base entity dismount logic.

This fixes ghost chicken jockeys that can occur in pigman farms.