### PR TITLE
Proper fix for disableVanillaTickWarp

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -288,9 +288,9 @@ public class CarpetSettings
   rule("tileTickLimit",         "survival", "Customizable tile tick limit")
                                 .extraInfo("Negative for no limit")
                                 .choices("65536","1000 65536 1000000").setNotStrict(),
-  rule("dismountFix",           "fix", "Fix dismount behavior that leads to ghost chicken jockeys")
+  rule("dismountFix",           "fix", "Fix dismount behavior that leads to ghost chicken jockeys"),
   rule("disableVanillaTickWarp", "fix", "Disables the catching-up behavior after lag spikes"),
-  rule("ridingPlayerUpdateFix", "fix", "Fixes chunk updates for players riding minecarts or llamas"),
+  rule("ridingPlayerUpdateFix", "fix", "Fixes chunk updates for players riding minecarts or llamas")
         };
         for (CarpetSettingEntry rule: RuleList)
         {

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -130,7 +130,7 @@
                              this.func_71217_p();
 +                            keeping_up = true;
 +                            if (CarpetSettings.disableVanillaTickWarp) {
-+                                i = 0;
++                                i = func_130071_aq() - k;
 +                                break;
 +                            }
                          }


### PR DESCRIPTION
As discussed in VC (`getCurrentTimeMillis() - timeBeforeTick`)