### PR TITLE
Fixed boolean value in CommandAutoSave

### DIFF
--- a/carpetmodSrc/carpet/commands/CommandAutosave.java
+++ b/carpetmodSrc/carpet/commands/CommandAutosave.java
@@ -105,7 +105,7 @@ public class CommandAutosave extends CommandCarpetBase {
 	
     public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos)
     {
-        if (!CarpetSettings.getBool("commandBlockInfo"))
+        if (!CarpetSettings.getBool("commandAutosave"))
         {
             return Collections.<String>emptyList();
         }


### PR DESCRIPTION
The if statement under getTabCompletions used to check for commandBlockInfo earlier....Now made it check for commandAutosave