### PR TITLE
Removed unnecessary getNBTDependentStackLimit function

### DIFF
--- a/patches/net/minecraft/item/Item.java.patch
+++ b/patches/net/minecraft/item/Item.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/item/Item.java
 +++ ../src-work/minecraft/net/minecraft/item/Item.java
-@@ -970,4 +970,10 @@
+@@ -970,4 +970,9 @@
              }
          }
      }
@@ -8,6 +8,5 @@
 +    /*
 +     * Fix for stack changes when doing NBT checks on shoulkers. CARPET-XCOM
 +     */
-+    public int getNBTDependentStackLimit(boolean hasTag){ return func_77639_j(); }
 +    public boolean itemGroundStacking(boolean hasTagCompound) { return false; }
  }

--- a/patches/net/minecraft/item/ItemShulkerBox.java.patch
+++ b/patches/net/minecraft/item/ItemShulkerBox.java.patch
@@ -8,19 +8,10 @@
  
  public class ItemShulkerBox extends ItemBlock
  {
-@@ -9,4 +10,21 @@
+@@ -9,4 +10,12 @@
          super(p_i47260_1_);
          this.func_77625_d(1);
      }
-+
-+    /*
-+     * Fix for chaning stack size using NBT or not CARPET-XCOM
-+     */
-+    @Override
-+    public int getNBTDependentStackLimit(boolean hasTag){
-+    	if(hasTag) return 1;
-+    	return func_77639_j();
-+    }
 +
 +    /*
 +     * Stack empty shulkers on the ground CARPET-XCOM

--- a/patches/net/minecraft/item/ItemStack.java.patch
+++ b/patches/net/minecraft/item/ItemStack.java.patch
@@ -19,18 +19,7 @@
          }
  
          return enumactionresult;
-@@ -207,7 +210,9 @@
- 
-     public int func_77976_d()
-     {
--        return this.func_77973_b().func_77639_j();
-+    	// Changed slightly for NBT stack changes CARPET-XCOM
-+        return this.func_77973_b().getNBTDependentStackLimit(func_77942_o());
-+        //return this.getItem().getItemStackLimit();
-     }
- 
-     public boolean func_77985_e()
-@@ -334,7 +339,8 @@
+@@ -334,7 +337,8 @@
  
          if (flag)
          {
@@ -40,7 +29,7 @@
          }
      }
  
-@@ -344,7 +350,8 @@
+@@ -344,7 +348,8 @@
  
          if (flag)
          {
@@ -50,7 +39,7 @@
          }
      }
  
-@@ -496,7 +503,8 @@
+@@ -496,7 +501,8 @@
  
      public void func_77980_a(World p_77980_1_, EntityPlayer p_77980_2_, int p_77980_3_)
      {
@@ -60,7 +49,7 @@
          this.func_77973_b().func_77622_d(this, p_77980_1_, p_77980_2_);
      }
  
-@@ -881,4 +889,9 @@
+@@ -881,4 +887,9 @@
      {
          this.func_190917_f(-p_190918_1_);
      }


### PR DESCRIPTION
I removed the getNBTDependentStackLimit function as it is only returning 1.
I also asked Xcom about the purpose of this function and he said it was meant for some complexer stacking.