### PR TITLE
Add effectsFix for MC-1541

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -100,6 +100,7 @@ public class CarpetSettings
     public static boolean ridingPlayerUpdateFix;
     public static boolean artificialPermaloader = false;
     public static int pistonClippingFix = 0;
+    public static boolean effectsFix = false;
 
     public static long setSeed = 0;
 
@@ -301,6 +302,7 @@ public class CarpetSettings
   rule("ridingPlayerUpdateFix", "fix", "Fixes chunk updates for players riding minecarts or llamas"),
   rule("pistonClippingFix",     "fix", "Fixes players clipping through moving piston blocks partially.")
                                 .choices("0", "0 20 40 100"),
+  rule("effectsFix",            "fix", "Recovers potion effects when they were replaced and the relacement ended"),
 
         };
         for (CarpetSettingEntry rule: RuleList)
@@ -350,6 +352,7 @@ public class CarpetSettings
         dismountFix = CarpetSettings.getBool("dismountFix");
         disableVanillaTickWarp = CarpetSettings.getBool("disableVanillaTickWarp");
         ridingPlayerUpdateFix = CarpetSettings.getBool("ridingPlayerUpdateFix");
+        effectsFix = CarpetSettings.getBool("effectsFix");
 
         if ("pistonGhostBlocksFix".equalsIgnoreCase(rule))
         {
@@ -753,6 +756,7 @@ public class CarpetSettings
         set("dismountFix","true");
         set("disableVanillaTickWarp","true");
         set("ridingPlayerUpdateFix","true");
+        set("effectsFix","true");
     }
 
     public static class CarpetSettingEntry 

--- a/patches/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/net/minecraft/entity/EntityLivingBase.java.patch
@@ -31,7 +31,38 @@
      }
  
      protected void func_70088_a()
-@@ -847,14 +857,20 @@
+@@ -741,8 +751,16 @@
+             }
+             else
+             {
+-                potioneffect.func_76452_a(p_70690_1_);
+-                this.func_70695_b(potioneffect, true);
++                PotionEffect newEffect = potioneffect.combine(p_70690_1_);
++                if (newEffect != potioneffect) {
++                    // carpet
++                    this.field_70713_bf.put(newEffect.func_188419_a(), newEffect);
++                    this.func_70688_c(potioneffect);
++                    this.func_70670_a(newEffect);
++                } else {
++                    // vanilla
++                    this.func_70695_b(newEffect, true);
++                }
+             }
+         }
+     }
+@@ -813,6 +831,11 @@
+         {
+             p_70688_1_.func_188419_a().func_111187_a(this, this.func_110140_aT(), p_70688_1_.func_76458_c());
+         }
++        // CM
++        if (CarpetSettings.effectsFix && p_70688_1_.previous != null) {
++            func_70690_d(p_70688_1_.previous);
++        }
++        // CM END
+     }
+ 
+     public void func_70691_i(float p_70691_1_)
+@@ -847,14 +870,20 @@
          }
          else
          {
@@ -53,7 +84,7 @@
                  return false;
              }
              else
-@@ -864,6 +880,7 @@
+@@ -864,6 +893,7 @@
                  if ((p_70097_1_ == DamageSource.field_82728_o || p_70097_1_ == DamageSource.field_82729_p) && !this.func_184582_a(EntityEquipmentSlot.HEAD).func_190926_b())
                  {
                      this.func_184582_a(EntityEquipmentSlot.HEAD).func_77972_a((int)(p_70097_2_ * 4.0F + this.field_70146_Z.nextFloat() * p_70097_2_ * 2.0F), this);
@@ -61,7 +92,7 @@
                      p_70097_2_ *= 0.75F;
                  }
  
-@@ -872,6 +889,7 @@
+@@ -872,6 +902,7 @@
                  if (p_70097_2_ > 0.0F && this.func_184583_d(p_70097_1_))
                  {
                      this.func_184590_k(p_70097_2_);
@@ -69,7 +100,7 @@
                      p_70097_2_ = 0.0F;
  
                      if (!p_70097_1_.func_76352_a())
-@@ -894,9 +912,10 @@
+@@ -894,9 +925,10 @@
                  {
                      if (p_70097_2_ <= this.field_110153_bc)
                      {
@@ -81,7 +112,7 @@
                      this.func_70665_d(p_70097_1_, p_70097_2_ - this.field_110153_bc);
                      this.field_110153_bc = p_70097_2_;
                      flag1 = false;
-@@ -1009,6 +1028,11 @@
+@@ -1009,6 +1041,11 @@
                  {
                      this.func_184581_c(p_70097_1_);
                  }
@@ -93,7 +124,7 @@
  
                  boolean flag2 = !flag || p_70097_2_ > 0.0F;
  
-@@ -1345,6 +1369,7 @@
+@@ -1345,6 +1382,7 @@
                  int i = (this.func_70660_b(MobEffects.field_76429_m).func_76458_c() + 1) * 5;
                  int j = 25 - i;
                  float f = p_70672_2_ * (float)j;
@@ -101,7 +132,7 @@
                  p_70672_2_ = f / 25.0F;
              }
  
-@@ -1358,7 +1383,10 @@
+@@ -1358,7 +1396,10 @@
  
                  if (k > 0)
                  {
@@ -112,7 +143,7 @@
                  }
  
                  return p_70672_2_;
-@@ -1370,15 +1398,21 @@
+@@ -1370,15 +1411,21 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -134,7 +165,7 @@
                  this.func_70606_j(f1 - p_70665_2_);
                  this.func_110142_aN().func_94547_a(p_70665_1_, f1, p_70665_2_);
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
-@@ -1828,7 +1862,10 @@
+@@ -1828,7 +1875,10 @@
                              }
                          }
  
@@ -145,7 +176,7 @@
  
                          if (this.field_70123_F && this.func_70617_f_())
                          {
-@@ -2330,8 +2367,13 @@
+@@ -2330,8 +2380,13 @@
                  }
              }
  
@@ -160,7 +191,7 @@
                  Entity entity = list.get(l);
                  this.func_82167_n(entity);
              }
-@@ -2366,6 +2408,11 @@
+@@ -2366,6 +2421,11 @@
      {
          this.field_70703_bu = p_70637_1_;
      }

--- a/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -107,3 +107,20 @@
          }
      }
  
+@@ -1169,7 +1206,7 @@
+ 
+     protected void func_70688_c(PotionEffect p_70688_1_)
+     {
+-        super.func_70688_c(p_70688_1_);
++        if (!CarpetSettings.effectsFix) super.func_70688_c(p_70688_1_);
+         this.field_71135_a.func_147359_a(new SPacketRemoveEntityEffect(this.func_145782_y(), p_70688_1_.func_188419_a()));
+ 
+         if (p_70688_1_.func_188419_a() == MobEffects.field_188424_y)
+@@ -1178,6 +1215,7 @@
+         }
+ 
+         CriteriaTriggers.field_193139_z.func_193153_a(this);
++        if (CarpetSettings.effectsFix) super.func_70688_c(p_70688_1_);
+     }
+ 
+     public void func_70634_a(double p_70634_1_, double p_70634_3_, double p_70634_5_)

--- a/patches/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/net/minecraft/potion/PotionEffect.java.patch
@@ -19,7 +19,7 @@
      public PotionEffect(Potion p_i46811_1_)
      {
          this(p_i46811_1_, 0, 0);
-@@ -49,12 +54,19 @@
+@@ -49,12 +54,32 @@
          this.field_188421_h = p_i1577_1_.field_188421_h;
      }
  
@@ -32,15 +32,28 @@
              field_180155_a.warn("This method should only be called for matching effects!");
          }
 +        // CM
-+        if (CarpetSettings.effectsFix && !this.field_82724_e && p_76452_1_.field_76461_c >= this.field_76461_c) {
-+            p_76452_1_.previous = this;
-+            return p_76452_1_;
++        if (p_76452_1_ == this) {
++            return this;
++        }
++        if (CarpetSettings.effectsFix && !this.field_82724_e && p_76452_1_.field_76461_c >= this.field_76461_c && p_76452_1_.field_76460_b < this.field_76460_b) {
++            boolean stack = true;
++            for (PotionEffect e = p_76452_1_; e != null; e = e.previous) {
++                if (e == this) {
++                    field_180155_a.warn("Tried to recursively combine effects " + this + " and " + p_76452_1_);
++                    stack = false;
++                    break;
++                }
++            }
++            if (stack) {
++                p_76452_1_.previous = this;
++                return p_76452_1_;
++            }
 +        }
 +        // CM END
  
          if (p_76452_1_.field_76461_c > this.field_76461_c)
          {
-@@ -71,6 +83,7 @@
+@@ -71,6 +96,7 @@
          }
  
          this.field_188421_h = p_76452_1_.field_188421_h;

--- a/patches/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/net/minecraft/potion/PotionEffect.java.patch
@@ -1,0 +1,50 @@
+--- ../src-base/minecraft/net/minecraft/potion/PotionEffect.java
++++ ../src-work/minecraft/net/minecraft/potion/PotionEffect.java
+@@ -6,6 +6,8 @@
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
++import carpet.CarpetSettings;
++
+ public class PotionEffect implements Comparable<PotionEffect>
+ {
+     private static final Logger field_180155_a = LogManager.getLogger();
+@@ -16,6 +18,9 @@
+     private boolean field_82724_e;
+     private boolean field_188421_h;
+ 
++    // CM
++    public PotionEffect previous;
++
+     public PotionEffect(Potion p_i46811_1_)
+     {
+         this(p_i46811_1_, 0, 0);
+@@ -49,12 +54,19 @@
+         this.field_188421_h = p_i1577_1_.field_188421_h;
+     }
+ 
+-    public void func_76452_a(PotionEffect p_76452_1_)
++    // Carpet: void -> PotionEffect, other -> p_76452_1_ for smaller diff
++    public PotionEffect combine(PotionEffect p_76452_1_)
+     {
+         if (this.field_188420_b != p_76452_1_.field_188420_b)
+         {
+             field_180155_a.warn("This method should only be called for matching effects!");
+         }
++        // CM
++        if (CarpetSettings.effectsFix && !this.field_82724_e && p_76452_1_.field_76461_c >= this.field_76461_c) {
++            p_76452_1_.previous = this;
++            return p_76452_1_;
++        }
++        // CM END
+ 
+         if (p_76452_1_.field_76461_c > this.field_76461_c)
+         {
+@@ -71,6 +83,7 @@
+         }
+ 
+         this.field_188421_h = p_76452_1_.field_188421_h;
++        return this; // Carpet added return
+     }
+ 
+     public Potion func_188419_a()


### PR DESCRIPTION
If `effectsFix` is enable this saves currently active portion effects and restores them when the overriding effect (for example by a beacon) runs out.