### PR TITLE
Fake player fixes

### DIFF
--- a/carpetmodSrc/carpet/commands/CommandPlayer.java
+++ b/carpetmodSrc/carpet/commands/CommandPlayer.java
@@ -131,9 +131,9 @@ public class CommandPlayer extends CommandCarpetBase
             {
                 throw new WrongUsageException("player "+playerName+" already exists");
             }
-            if (playerName.length()<3 || playerName.length()>11)
+            if (playerName.length() < 3 || playerName.length() > 16)
             {
-                throw new WrongUsageException("player names can only be 3 to 11 chars long");
+                throw new WrongUsageException("player names can only be 3 to 16 chars long");
             }
             Vec3d vec3d = sender.getPositionVector();
             double d0 = vec3d.x;

--- a/carpetmodSrc/carpet/helpers/EntityPlayerActionPack.java
+++ b/carpetmodSrc/carpet/helpers/EntityPlayerActionPack.java
@@ -11,6 +11,7 @@ import net.minecraft.block.BlockStructure;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -248,8 +249,12 @@ public class EntityPlayerActionPack
     }
     public void mount()
     {
-        List<Entity> entities = player.world.getEntitiesWithinAABBExcludingEntity(player,player.getEntityBoundingBox().expand(3.0D, 1.0D, 3.0D));
-        if (entities.size()==0)
+        List<Entity> entities = player.world.getEntitiesInAABBexcluding(
+                player,
+                player.getEntityBoundingBox().expand(3.0D, 1.0D, 3.0D),
+                other -> !(other instanceof EntityPlayer)
+        );
+        if (entities.size() == 0)
         {
             return;
         }

--- a/carpetmodSrc/carpet/patches/EntityPlayerMPFake.java
+++ b/carpetmodSrc/carpet/patches/EntityPlayerMPFake.java
@@ -95,11 +95,13 @@ public class EntityPlayerMPFake extends EntityPlayerMP
             return gameProfile;
     }
 
+    @Override
     public void onKillCommand()
     {
-        this.getServer().getPlayerList().playerLoggedOut(this);
+        logout();
     }
 
+    @Override
     public void onUpdate()
     {
         super.onUpdate();
@@ -111,6 +113,11 @@ public class EntityPlayerMPFake extends EntityPlayerMP
     public void onDeath(DamageSource cause)
     {
         super.onDeath(cause);
+        logout();
+    }
+
+    private void logout() {
+        this.dismountRidingEntity();
         getServer().getPlayerList().playerLoggedOut(this);
     }
 

--- a/carpetmodSrc/carpet/patches/EntityPlayerMPFake.java
+++ b/carpetmodSrc/carpet/patches/EntityPlayerMPFake.java
@@ -54,6 +54,7 @@ public class EntityPlayerMPFake extends EntityPlayerMP
         server.getPlayerList().sendPacketToAllPlayersInDimension(new SPacketEntityHeadLook(instance, (byte)(instance.rotationYawHead * 256 / 360) ),instance.dimension);
         server.getPlayerList().sendPacketToAllPlayersInDimension(new SPacketEntityTeleport(instance),instance.dimension);
         server.getPlayerList().serverUpdateMovingPlayer(instance);
+        instance.dataManager.set(PLAYER_MODEL_FLAG, (byte) 0x7f); // show all model layers (incl. capes)
         return instance;
     }
 


### PR DESCRIPTION
- Show all model parts (including capes)
- Adjust name length limit to 3-16 (https://help.mojang.com/customer/en/portal/articles/928638-minecraft-usernames)
- Dismount before logout
- Don't mount players