### PR TITLE
Fix prepare fake player

### DIFF
--- a/carpetmodSrc/carpet/patches/EntityPlayerMPFake.java
+++ b/carpetmodSrc/carpet/patches/EntityPlayerMPFake.java
@@ -43,7 +43,7 @@ public class EntityPlayerMPFake extends EntityPlayerMP
             instance.isDead = false;
             worldIn.spawnEntity(instance);
             instance.setWorld(worldIn);
-            server.getPlayerList().preparePlayer(instance, worldIn);
+            server.getPlayerList().preparePlayer(instance, old_world);
             instance.connection.setPlayerLocation(x, y, z, (float)yaw, (float)pitch);
             instance.interactionManager.setWorld(worldIn);
         }


### PR DESCRIPTION
If you summon a fakeplayer in a non-overworld dimension they create a renderdistance sized area of player loaded chunks in overworld and u can't unload it. This fixes it