### PR TITLE
Fix findAll filtering

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -1001,7 +1001,7 @@ public class CarpetSettings
                     if (actualFilter == null) return true;
                     if (rule.contains(actualFilter)) return true;
                     for (RuleCategory ctgy : getCategories(rule))
-                        if (ctgy.name().equalsIgnoreCase(rule))
+                        if (ctgy.name().equalsIgnoreCase(actualFilter))
                             return true;
                     return false;
                 })


### PR DESCRIPTION
Fixes for /carpet list creative not showing all entries.

In the CarpetSettings findAll function is this line:
`if (ctgy.name().equalsIgnoreCase(rule))`
instead of checking against the actualFilter variable the check was against the rule variable.