### PR TITLE
Fixed Carpet Client Rule Changer

### DIFF
--- a/carpetmodSrc/carpet/carpetclient/CarpetClientRuleChanger.java
+++ b/carpetmodSrc/carpet/carpetclient/CarpetClientRuleChanger.java
@@ -1,5 +1,6 @@
 package carpet.carpetclient;
 
+import com.google.common.collect.Lists;
 import io.netty.buffer.Unpooled;
 import net.minecraft.entity.player.EntityPlayerMP;
 import carpet.CarpetSettings;
@@ -28,6 +29,10 @@ public class CarpetClientRuleChanger {
 			if (sender.canUseCommand(2, "carpet")) {
 				String[] options = CarpetSettings.getOptions(rule);
 				int index = valueIndex.getOrDefault(rule.toLowerCase(Locale.ENGLISH), -1);
+				if (index == -1) {
+					String value = CarpetSettings.get(rule);
+					index = Lists.newArrayList(options).indexOf(value);
+				}
 				index = (index + 1) % options.length;
 				valueIndex.put(rule.toLowerCase(Locale.ENGLISH), index);
 				String value = options[index];


### PR DESCRIPTION
Small fix for the carpet client rule changer.

In case of a boolean rule: if the valueIndex has no entry for the current rule and current value was false, there will be no change to the rule as -1+1= 0 and therefore is "false" in the options list.
This little if statement is taking care of this and incase of index == -1 is getting the index of the current value.