### PR TITLE
Prevent carpetmod from sending the update package twice.

### DIFF
--- a/carpetmodSrc/carpet/carpetclient/CarpetClientRuleChanger.java
+++ b/carpetmodSrc/carpet/carpetclient/CarpetClientRuleChanger.java
@@ -58,7 +58,6 @@ public class CarpetClientRuleChanger {
 		CarpetSettings.set(rule, value);
 		String s = CarpetSettings.getDescription(rule) + " is set to: " + CarpetSettings.get(rule);
         Messenger.print_server_message(sender.getEntityWorld().getMinecraftServer(), s);
-		updateCarpetClientsRule(rule, value);
 	}
 
 	public static void updateCarpetClientsRule(String rule, String value) {


### PR DESCRIPTION
Because in CarpetSettings set function the update routine gets called it is safe to remove the routein in the rule change logic function,
This prevents carpetmod from sending the rule change packet twice.