### PR TITLE
Implemented log changes 

### DIFF
--- a/carpetmodSrc/carpet/CarpetServer.java
+++ b/carpetmodSrc/carpet/CarpetServer.java
@@ -56,6 +56,7 @@ public class CarpetServer // static for now - easier to handle all around the co
     {
         CarpetSettings.applySettingsFromConf(server);
         LoggerRegistry.initLoggers(server);
+        LoggerRegistry.readSaveFile(server);
         WorldEditBridge.onServerLoaded(server);
 
         // Precache mappings so as not to lag the server later

--- a/carpetmodSrc/carpet/logging/LogHandler.java
+++ b/carpetmodSrc/carpet/logging/LogHandler.java
@@ -62,13 +62,22 @@ public abstract class LogHandler
     
     public static LogHandler createHandler(String name, String... extraArgs)
     {
-        return CREATORS.get(name).create(extraArgs);
+        LogHandler handler = CREATORS.get(name).create(extraArgs);
+        handler.name = name;
+        handler.extraArgs = extraArgs;
+        return handler;
     }
     
     public static List<String> getHandlerNames()
     {
         return CREATORS.keySet().stream().sorted().collect(Collectors.toList());
     }
+
+    private String name;
+    private String[] extraArgs;
+
+    public String getName() { return name; }
+    public String[] getExtraArgs() { return extraArgs; }
     
     public abstract void handle(EntityPlayerMP player, ITextComponent[] message, Object[] commandParams);
     

--- a/carpetmodSrc/carpet/logging/LoggerOptions.java
+++ b/carpetmodSrc/carpet/logging/LoggerOptions.java
@@ -1,0 +1,56 @@
+package carpet.logging;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.util.IJsonSerializable;
+
+public class LoggerOptions implements IJsonSerializable {
+    public String logger;
+    public String option;
+    public String handlerName;
+    public String[] extraArgs;
+
+    LoggerOptions() {}
+
+    public LoggerOptions(String logger, String option, String handlerName, String... extraArgs) {
+        this.logger = logger;
+        this.option = option;
+        this.handlerName = handlerName;
+        this.extraArgs = extraArgs;
+    }
+
+    @Override
+    public void fromJson(JsonElement json) {
+        JsonObject obj = (JsonObject)json;
+
+        logger = obj.get("logger").getAsString();
+        if (!obj.get("option").isJsonNull())
+            option = obj.get("option").getAsString();
+        if (!obj.get("handlerName").isJsonNull())
+            handlerName = obj.get("handlerName").getAsString();
+
+        JsonArray args = obj.getAsJsonArray("extraArgs");
+        extraArgs = new String[args.size()];
+        for (int i = 0; i < extraArgs.length; ++i) {
+            extraArgs[i++] = args.get(i).getAsString();
+        }
+    }
+
+    @Override
+    public JsonElement getSerializableElement() {
+        JsonObject entry = new JsonObject();
+
+        entry.addProperty("logger", logger);
+        entry.addProperty("option", option);
+        entry.addProperty("handlerName", handlerName);
+
+        JsonArray args = new JsonArray();
+        for (String extraArg : this.extraArgs) {
+            args.add(extraArg);
+        }
+        entry.add("extraArgs", args);
+
+        return entry;
+    }
+}

--- a/carpetmodSrc/carpet/logging/LoggerRegistry.java
+++ b/carpetmodSrc/carpet/logging/LoggerRegistry.java
@@ -1,10 +1,16 @@
 package carpet.logging;
 
 import carpet.CarpetSettings;
+import com.google.common.base.Charsets;
+import com.google.gson.*;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.server.MinecraftServer;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -13,10 +19,16 @@ import java.util.Set;
 
 public class LoggerRegistry
 {
+    private static final org.apache.logging.log4j.Logger LOGGER = LogManager.getLogger();
+
     // Map from logger names to loggers.
     private static Map<String, Logger> loggerRegistry = new HashMap<>();
+
+    // List of default subscriptions
+    private static Map<String, LoggerOptions> defaultSubscriptions = new HashMap<>();
     // Map from player names to the set of names of the logs that player is subscribed to.
-    private static Map<String, Map<String, String>> playerSubscriptions = new HashMap<>();
+    private static Map<String, Map<String, LoggerOptions>> playerSubscriptions = new HashMap<>();
+
     //statics to quickly asses if its worth even to call each one
     public static boolean __tnt;
     public static boolean __projectiles;
@@ -48,6 +60,91 @@ public class LoggerRegistry
         registerLogger("mobcaps", new Logger(server, "mobcaps", "dynamic",new String[]{"dynamic", "overworld", "nether","end"}, LogHandler.HUD));
     }
 
+    private static File getSaveFile(MinecraftServer server) { return server.getActiveAnvilConverter().getFile(server.getFolderName(), "loggerData.json"); }
+
+    public static void readSaveFile(MinecraftServer server) {
+        File logData = getSaveFile(server);
+        if (logData.isFile()) {
+            try {
+                JsonElement root = (new JsonParser()).parse(FileUtils.readFileToString(logData, Charsets.UTF_8));
+                if (!root.isJsonObject())
+                    return;
+
+                JsonObject rootObj = root.getAsJsonObject();
+
+                JsonArray defaultList = rootObj.getAsJsonArray("defaultList");
+                for (JsonElement entryElement : defaultList) {
+                    LoggerOptions options = new LoggerOptions();
+                    options.fromJson(entryElement);
+
+                    defaultSubscriptions.put(options.logger, options);
+                }
+
+                JsonObject playerList = rootObj.getAsJsonObject("players");
+                for (Map.Entry<String, JsonElement> playerEntry : playerList.entrySet()) {
+                    String username = playerEntry.getKey();
+                    Map<String, LoggerOptions> subs = new HashMap<>();
+
+                    JsonArray loggerEntries = playerEntry.getValue().getAsJsonArray();
+                    for (JsonElement entryElement : loggerEntries) {
+                        LoggerOptions options = new LoggerOptions();
+                        options.fromJson(entryElement);
+
+                        subs.put(options.logger, options);
+                    }
+
+                    playerSubscriptions.put(username, subs);
+                }
+            }
+            catch (IOException ioexception)
+            {
+                LOGGER.error("Couldn't read default logger file {}", logData, ioexception);
+            }
+            catch (JsonParseException jsonparseexception)
+            {
+                LOGGER.error("Couldn't parse default logger file {}", logData, jsonparseexception);
+            }
+        }
+    }
+
+    public static void writeConf(MinecraftServer server) {
+        File logData = getSaveFile(server);
+        try
+        {
+            JsonObject root = new JsonObject();
+
+            JsonArray defaultList = new JsonArray();
+            for (Map.Entry<String, LoggerOptions> logger : defaultSubscriptions.entrySet()) {
+                defaultList.add(logger.getValue().getSerializableElement());
+            }
+            root.add("defaultList", defaultList);
+
+            JsonObject playerList = new JsonObject();
+            for (Map.Entry<String, Map<String, LoggerOptions>> playerEntry : playerSubscriptions.entrySet()) {
+                JsonArray playerLoggers = new JsonArray();
+
+                for (LoggerOptions logger : playerEntry.getValue().values()) {
+                    playerLoggers.add(logger.getSerializableElement());
+                }
+
+                playerList.add(playerEntry.getKey(), playerLoggers);
+            }
+            root.add("players", playerList);
+
+            FileUtils.writeStringToFile(logData, root.toString(), Charsets.UTF_8);
+        }
+        catch (IOException ioexception)
+        {
+            LOGGER.error("Couldn't save stats", (Throwable)ioexception);
+        }
+    }
+
+
+    /**
+     * Gets the default subscriptions
+     */
+    public static Map<String, LoggerOptions> getDefaultSubscriptions() { return defaultSubscriptions; }
+
     /**
      * Gets the logger with the given name. Returns null if no such logger exists.
      */
@@ -59,64 +156,145 @@ public class LoggerRegistry
     public static Set<String> getLoggerNames() { return loggerRegistry.keySet(); }
 
     /**
+     * Sets a log as a default log with the specified option and handler
+     */
+    public static boolean setDefault(MinecraftServer server, String logName, String option, LogHandler handler) {
+        if (handler != null) {
+            defaultSubscriptions.put(logName, new LoggerOptions(logName, option, handler.getName(), handler.getExtraArgs()));
+        } else {
+            defaultSubscriptions.put(logName, new LoggerOptions(logName, option, null));
+        }
+        writeConf(server);
+
+        // Subscribe all players who have no customized subscription list
+        for (EntityPlayer player : server.getPlayerList().getPlayers()) {
+            if (!hasSubscriptions(player.getName()))
+                subscribePlayer(player.getName(), logName, option, handler);
+        }
+        return true;
+    }
+
+    /**
+     * Removes a log fro mthe list of default logs
+     */
+    public static boolean removeDefault(MinecraftServer server, String logName) {
+        if (defaultSubscriptions.containsKey(logName)) {
+            defaultSubscriptions.remove(logName);
+            writeConf(server);
+
+            // Unsubscribe all players who have no customized subscription list
+            for (EntityPlayer player : server.getPlayerList().getPlayers()) {
+                if (!hasSubscriptions(player.getName()))
+                    unsubscribePlayer(player.getName(), logName);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if a player is actively subscribed to anything
+     */
+    public static boolean hasSubscriptions(String playerName) { return playerSubscriptions.containsKey(playerName); }
+
+    /**
+     * Get the set of logs the current player is subscribed to.
+     */
+    public static Map<String, LoggerOptions> getPlayerSubscriptions(String playerName) {
+        return playerSubscriptions.getOrDefault(playerName, new HashMap<>(defaultSubscriptions));
+    }
+
+    /**
      * Subscribes the player with name playerName to the log with name logName.
      */
-    public static void subscribePlayer(String playerName, String logName, String option, LogHandler handler)
+    public static boolean subscribePlayer(MinecraftServer server, String playerName, String logName, String option, LogHandler handler)
     {
-        if (!playerSubscriptions.containsKey(playerName)) playerSubscriptions.put(playerName, new HashMap<>());
-        Logger log = loggerRegistry.get(logName);
-        if (option == null) option = log.getDefault();
-        playerSubscriptions.get(playerName).put(logName,option);
-        log.addPlayer(playerName, option, handler);
+        if (!hasSubscriptions(playerName)) {
+            playerSubscriptions.put(playerName, new HashMap<>(defaultSubscriptions));
+        }
+
+        Map<String, LoggerOptions> subs = getPlayerSubscriptions(playerName);
+        if (!subs.containsKey(logName)) {
+            if (handler != null) {
+                subs.put(logName, new LoggerOptions(logName, option, handler.getName(), handler.getExtraArgs()));
+            } else {
+                subs.put(logName, new LoggerOptions(logName, option, null));
+            }
+
+            subscribePlayer(playerName, logName, option, handler);
+            writeConf(server);
+            return true;
+        }
+        return false;
     }
 
     /**
      * Unsubscribes the player with name playerName from the log with name logName.
      */
-    public static void unsubscribePlayer(String playerName, String logName)
+    public static boolean unsubscribePlayer(MinecraftServer server, String playerName, String logName)
     {
-        if (playerSubscriptions.containsKey(playerName))
-        {
-            Map<String,String> subscriptions = playerSubscriptions.get(playerName);
-            subscriptions.remove(logName);
-            loggerRegistry.get(logName).removePlayer(playerName);
-            if (subscriptions.size() == 0) playerSubscriptions.remove(playerName);
+        if (!hasSubscriptions(playerName)) {
+            playerSubscriptions.put(playerName, new HashMap<>(defaultSubscriptions));
         }
+
+        Map<String, LoggerOptions> subs = getPlayerSubscriptions(playerName);
+        if (subs.containsKey(logName)) {
+            subs.remove(logName);
+            unsubscribePlayer(playerName, logName);
+            writeConf(server);
+            return true;
+        }
+        return false;
     }
 
     /**
      * If the player is not subscribed to the log, then subscribe them. Otherwise, unsubscribe them.
      */
-    public static boolean togglePlayerSubscription(String playerName, String logName, LogHandler handler)
+    public static boolean togglePlayerSubscription(MinecraftServer server, String playerName, String logName, LogHandler handler)
     {
-        if (playerSubscriptions.containsKey(playerName) && playerSubscriptions.get(playerName).containsKey(logName))
+        if (getPlayerSubscriptions(playerName).containsKey(logName))
         {
-            unsubscribePlayer(playerName, logName);
+            unsubscribePlayer(server, playerName, logName);
             return false;
         }
         else
         {
-            subscribePlayer(playerName, logName, null, handler);
+            subscribePlayer(server, playerName, logName, null, handler);
             return true;
         }
     }
 
     /**
-     * Get the set of logs the current player is subscribed to.
+     * Unsubscribes a player from all logs and removes the subscription entry
+     * This restores the default subscriptions
      */
-    public static Map<String,String> getPlayerSubscriptions(String playerName)
-    {
-        if (playerSubscriptions.containsKey(playerName))
-        {
-            return playerSubscriptions.get(playerName);
+    public static void resetSubscriptions(MinecraftServer server, String playerName) {
+        Map<String, LoggerOptions> subs = getPlayerSubscriptions(playerName);
+
+        // Unsubscribe from all subscriptions
+        for (String logName : subs.keySet()) {
+            unsubscribePlayer(playerName, logName);
         }
-        return null;
+
+        if (hasSubscriptions(playerName))
+            playerSubscriptions.remove(playerName);
+
+        writeConf(server);
+
+        // Restore default subscriptions
+        for (LoggerOptions option : defaultSubscriptions.values()) {
+            LogHandler handler = null;
+            if (option.handlerName != null)
+                handler = LogHandler.createHandler(option.handlerName, option.extraArgs);
+
+            subscribePlayer(playerName, option.logger, option.option, handler);
+        }
     }
 
     protected static void setAccess(Logger logger)
     {
         String name = logger.getLogName();
-        boolean value = logger.hasOnlineSubscribers();
+        boolean value = logger.hasSubscribers();
         try
         {
             Field f = LoggerRegistry.class.getDeclaredField("__"+name);
@@ -140,22 +318,39 @@ public class LoggerRegistry
         setAccess(logger);
     }
 
+
     public static void playerConnected(EntityPlayer player)
     {
-        for(Logger log: loggerRegistry.values() )
-        {
-            log.onPlayerConnect(player);
-        }
+        String playerName = player.getName();
 
+        Map<String, LoggerOptions> subs = getPlayerSubscriptions(playerName);
+        for (LoggerOptions option : subs.values()) {
+            LogHandler handler = null;
+            if (option.handlerName != null)
+                handler = LogHandler.createHandler(option.handlerName, option.extraArgs);
+
+            subscribePlayer(playerName, option.logger, option.option, handler);
+        }
     }
     public static void playerDisconnected(EntityPlayer player)
     {
-        for(Logger log: loggerRegistry.values() )
-        {
-            log.onPlayerDisconnect(player);
+        String playerName = player.getName();
+
+        for (String logName : LoggerRegistry.getLoggerNames()) {
+            unsubscribePlayer(playerName, logName);
         }
     }
 
+    // ===== PRIVATE FUNCTIONS TO PREVENT CODE DUPLICATION ===== //
+    private static void subscribePlayer(String playerName, String logName, String option, LogHandler handler) {
+        carpet.logging.Logger log = LoggerRegistry.getLogger(logName);
+        if (option == null)
+            option = log.getDefault();
 
+        log.addPlayer(playerName, option, handler);
+    }
 
+    private static void unsubscribePlayer(String playerName, String logName) {
+        LoggerRegistry.getLogger(logName).removePlayer(playerName);
+    }
 }

--- a/carpetmodSrc/carpet/logging/logHelpers/TrajectoryLogHelper.java
+++ b/carpetmodSrc/carpet/logging/logHelpers/TrajectoryLogHelper.java
@@ -26,7 +26,7 @@ public class TrajectoryLogHelper
     public TrajectoryLogHelper(String logName)
     {
         this.logger = LoggerRegistry.getLogger(logName);
-        this.doLog = this.logger.hasOnlineSubscribers();
+        this.doLog = this.logger.hasSubscribers();
         sentLogs = 0;
     }
 


### PR DESCRIPTION
Based on issue #53 I implemented the changes.
I would like to get some feedback on this and maybe some improvement suggestions.


A bit of explaination:
Implemented persistent log options per-player as well as a server default configuration possability.

Server owners can either use the "/log defaults" command which provides an interactive menu or use the "/log setDefault" and "/log removeDefault" synatx to toggle the default subscriptions.

Players on the otherhand will be subscribed to the default subscriptions until they change their logging options, this way it's possible to have no log subscriptions at all.

Players can get back to the default subscriptions by using "/log reset", server owners can also force a "/log reset" on a player.
The clear option got renamed to reset as now it would have been misunderstandable. 

Subscriptions are now persistent and stored in a JSON file inside the world folder.


