### PR TITLE
Chunk savestate near players

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -355,6 +355,18 @@ public class CarpetSettings
 
     @Rule(desc = "Allows players to place blocks inside entity's.", category = {CREATIVE})
     public static boolean ignoreEntityWhenPlacing = false;
+
+    public static enum WhereToChunkSavestate {
+        unload(false), everywhere_except_players(true), everywhere(true);
+        public final boolean canUnloadNearPlayers;
+        WhereToChunkSavestate(boolean canUnloadNearPlayers) {
+            this.canUnloadNearPlayers = canUnloadNearPlayers;
+        }
+    }
+
+    @Rule(desc = "Where chunk savestating is allowed to happen", category = CREATIVE)
+    public static WhereToChunkSavestate whereToChunkSavestate = WhereToChunkSavestate.unload;
+
     // ===== FIXES ===== //
     /*
      * Rules in this category should end with the "Fix" suffix

--- a/patches/net/minecraft/server/management/PlayerChunkMapEntry.java.patch
+++ b/patches/net/minecraft/server/management/PlayerChunkMapEntry.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/server/management/PlayerChunkMapEntry.java
 +++ ../src-work/minecraft/net/minecraft/server/management/PlayerChunkMapEntry.java
-@@ -19,11 +19,14 @@
+@@ -19,25 +19,31 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
@@ -16,7 +16,15 @@
      private final ChunkPos field_187284_d;
      private final short[] field_187285_e = new short[64];
      @Nullable
-@@ -37,7 +40,10 @@
+-    private Chunk field_187286_f;
++    public Chunk field_187286_f; // CM: changed to public
+     private int field_187287_g;
+     private int field_187288_h;
+     private long field_187289_i;
+-    private boolean field_187290_j;
++    public boolean field_187290_j; // CM: changed to public
+ 
+     public PlayerChunkMapEntry(PlayerChunkMap p_i1518_1_, int p_i1518_2_, int p_i1518_3_)
      {
          this.field_187282_b = p_i1518_1_;
          this.field_187284_d = new ChunkPos(p_i1518_2_, p_i1518_3_);

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/world/WorldServer.java
 +++ ../src-work/minecraft/net/minecraft/world/WorldServer.java
-@@ -60,6 +60,7 @@
+@@ -14,7 +14,6 @@
+ import java.util.Set;
+ import java.util.TreeSet;
+ import java.util.UUID;
+-import java.util.function.Predicate;
+ import java.util.stream.Collectors;
+ import javax.annotation.Nullable;
+ import net.minecraft.advancements.AdvancementManager;
+@@ -60,6 +59,7 @@
  import net.minecraft.util.math.ChunkPos;
  import net.minecraft.util.math.MathHelper;
  import net.minecraft.util.math.Vec3d;
@@ -8,7 +16,7 @@
  import net.minecraft.village.VillageCollection;
  import net.minecraft.village.VillageSiege;
  import net.minecraft.world.biome.Biome;
-@@ -80,14 +81,22 @@
+@@ -80,14 +80,22 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
@@ -34,7 +42,7 @@
      private final Map<UUID, Entity> field_175741_N = Maps.<UUID, Entity>newHashMap();
      public boolean field_73058_d;
      private boolean field_73068_P;
-@@ -99,6 +108,11 @@
+@@ -99,6 +107,11 @@
      private int field_147489_T;
      private final List<NextTickListEntry> field_94579_S = Lists.<NextTickListEntry>newArrayList();
  
@@ -46,7 +54,7 @@
      public WorldServer(MinecraftServer p_i45921_1_, ISaveHandler p_i45921_2_, WorldInfo p_i45921_3_, int p_i45921_4_, Profiler p_i45921_5_)
      {
          super(p_i45921_2_, p_i45921_3_, DimensionType.func_186069_a(p_i45921_4_).func_186070_d(), p_i45921_5_, false);
-@@ -164,6 +178,9 @@
+@@ -164,6 +177,9 @@
  
      public void func_72835_b()
      {
@@ -56,7 +64,7 @@
          super.func_72835_b();
  
          if (this.func_72912_H().func_76093_s() && this.func_175659_aa() != EnumDifficulty.HARD)
-@@ -184,12 +201,19 @@
+@@ -184,12 +200,19 @@
              this.func_73053_d();
          }
  
@@ -76,7 +84,7 @@
  
          this.field_72984_F.func_76318_c("chunkSource");
          this.field_73020_y.func_73156_b();
-@@ -200,26 +224,56 @@
+@@ -200,26 +223,56 @@
              this.func_175692_b(j);
          }
  
@@ -135,7 +143,7 @@
      }
  
      @Nullable
-@@ -255,8 +309,15 @@
+@@ -255,8 +308,15 @@
                      ++j;
                  }
              }
@@ -153,7 +161,7 @@
          }
      }
  
-@@ -287,6 +348,28 @@
+@@ -287,6 +347,28 @@
      {
          if (this.field_73068_P && !this.field_72995_K)
          {
@@ -182,7 +190,7 @@
              for (EntityPlayer entityplayer : this.field_73010_i)
              {
                  if (!entityplayer.func_175149_v() && !entityplayer.func_71026_bH())
-@@ -303,7 +386,7 @@
+@@ -303,7 +385,7 @@
          }
      }
  
@@ -191,7 +199,7 @@
      {
          return this.func_72863_F().func_73149_a(p_175680_1_, p_175680_2_);
      }
-@@ -344,6 +427,7 @@
+@@ -344,6 +426,7 @@
              boolean flag = this.func_72896_J();
              boolean flag1 = this.func_72911_I();
              this.field_72984_F.func_76320_a("pollingChunks");
@@ -199,7 +207,7 @@
  
              for (Iterator<Chunk> iterator = this.field_73063_M.func_187300_b(); iterator.hasNext(); this.field_72984_F.func_76319_b())
              {
-@@ -355,9 +439,14 @@
+@@ -355,9 +438,14 @@
                  chunk.func_76594_o();
                  this.field_72984_F.func_76318_c("tickChunk");
                  chunk.func_150804_b(false);
@@ -215,7 +223,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int l = this.field_73005_l >> 2;
-@@ -385,7 +474,7 @@
+@@ -385,7 +473,7 @@
  
                  this.field_72984_F.func_76318_c("iceandsnow");
  
@@ -224,7 +232,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int j2 = this.field_73005_l >> 2;
-@@ -443,7 +532,7 @@
+@@ -443,7 +531,7 @@
          }
      }
  
@@ -233,7 +241,7 @@
      {
          BlockPos blockpos = this.func_175725_q(p_175736_1_);
          AxisAlignedBB axisalignedbb = (new AxisAlignedBB(blockpos, new BlockPos(blockpos.func_177958_n(), this.func_72800_K(), blockpos.func_177952_p()))).func_186662_g(3.0D);
-@@ -503,9 +592,10 @@
+@@ -503,9 +591,10 @@
                      {
                          iblockstate.func_177230_c().func_180650_b(this, p_175654_1_, iblockstate, this.field_73012_v);
                      }
@@ -245,7 +253,7 @@
              }
  
              p_175654_3_ = 1;
-@@ -644,9 +734,18 @@
+@@ -644,9 +733,18 @@
              }
              else
              {
@@ -266,7 +274,7 @@
                  }
  
                  this.field_72984_F.func_76320_a("cleaning");
-@@ -677,6 +776,8 @@
+@@ -677,6 +775,8 @@
  
                      if (this.func_175707_a(nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0), nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0)))
                      {
@@ -275,7 +283,7 @@
                          IBlockState iblockstate = this.func_180495_p(nextticklistentry1.field_180282_a);
  
                          if (iblockstate.func_185904_a() != Material.field_151579_a && Block.func_149680_a(iblockstate.func_177230_c(), nextticklistentry1.func_151351_a()))
-@@ -699,6 +800,7 @@
+@@ -699,6 +799,7 @@
                          this.func_175684_a(nextticklistentry1.field_180282_a, nextticklistentry1.func_151351_a(), 0);
                      }
                  }
@@ -283,7 +291,24 @@
  
                  this.field_72984_F.func_76319_b();
                  this.field_94579_S.clear();
-@@ -1055,6 +1157,7 @@
+@@ -952,9 +1053,15 @@
+ 
+             for (Chunk chunk : Lists.newArrayList(chunkproviderserver.func_189548_a()))
+             {
+-                if (chunk != null && !this.field_73063_M.func_152621_a(chunk.field_76635_g, chunk.field_76647_h))
++                if (chunk != null /*&& !this.playerChunkMap.contains(chunk.x, chunk.z)*/) // CM: moved test to below
+                 {
++                    if (!this.field_73063_M.func_152621_a(chunk.field_76635_g, chunk.field_76647_h))
+                     chunkproviderserver.func_189549_a(chunk);
++                    else if (CarpetSettings.whereToChunkSavestate.canUnloadNearPlayers)
++                    {
++                        chunkproviderserver.func_189549_a(chunk);
++                        chunk.field_189550_d = false;
++                    }
+                 }
+             }
+         }
+@@ -1055,6 +1162,7 @@
          this.field_175729_l.func_76038_a(p_72923_1_.func_145782_y(), p_72923_1_);
          this.field_175741_N.put(p_72923_1_.func_110124_au(), p_72923_1_);
          Entity[] aentity = p_72923_1_.func_70021_al();
@@ -291,7 +316,7 @@
  
          if (aentity != null)
          {
-@@ -1150,14 +1253,19 @@
+@@ -1150,14 +1258,19 @@
  
              for (BlockEventData blockeventdata : this.field_147490_S[i])
              {
@@ -311,7 +336,7 @@
      }
  
      private boolean func_147485_a(BlockEventData p_147485_1_)
-@@ -1299,4 +1407,9 @@
+@@ -1299,4 +1412,9 @@
              {
              }
          }

--- a/patches/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -211,7 +211,17 @@
      }
  
      private void func_183013_b(ChunkPos p_183013_1_, NBTTagCompound p_183013_2_) throws IOException
-@@ -295,6 +377,10 @@
+@@ -249,7 +331,8 @@
+         });
+     }
+ 
+-    private void func_75820_a(Chunk p_75820_1_, World p_75820_2_, NBTTagCompound p_75820_3_)
++    // CM: change access to public & static
++    public static void func_75820_a(Chunk p_75820_1_, World p_75820_2_, NBTTagCompound p_75820_3_)
+     {
+         p_75820_3_.func_74768_a("xPos", p_75820_1_.field_76635_g);
+         p_75820_3_.func_74768_a("zPos", p_75820_1_.field_76647_h);
+@@ -295,6 +378,10 @@
          }
  
          p_75820_3_.func_74782_a("Sections", nbttaglist);
@@ -222,7 +232,7 @@
          p_75820_3_.func_74773_a("Biomes", p_75820_1_.func_76605_m());
          p_75820_1_.func_177409_g(false);
          NBTTagList nbttaglist1 = new NBTTagList();
-@@ -383,6 +469,11 @@
+@@ -383,6 +470,11 @@
  
          chunk.func_76602_a(aextendedblockstorage);
  

--- a/patches/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/ChunkProviderServer.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/ChunkProviderServer.java
-@@ -27,13 +27,19 @@
+@@ -27,13 +27,21 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
@@ -8,7 +8,9 @@
 +import carpet.CarpetSettings;
 +import carpet.carpetclient.CarpetClientChunkLogger;
 +import carpet.utils.TickingArea;
++import carpet.utils.UnloadOrder;
 +import net.minecraft.entity.Entity;
++import net.minecraft.server.management.PlayerChunkMapEntry;
 +
  public class ChunkProviderServer implements IChunkProvider
  {
@@ -24,7 +26,7 @@
      private final WorldServer field_73251_h;
  
      public ChunkProviderServer(WorldServer p_i46838_1_, IChunkLoader p_i46838_2_, IChunkGenerator p_i46838_3_)
-@@ -50,8 +56,18 @@
+@@ -50,8 +58,18 @@
  
      public void func_189549_a(Chunk p_189549_1_)
      {
@@ -44,7 +46,7 @@
              this.field_73248_b.add(Long.valueOf(ChunkPos.func_77272_a(p_189549_1_.field_76635_g, p_189549_1_.field_76647_h)));
              p_189549_1_.field_189550_d = true;
          }
-@@ -76,6 +92,11 @@
+@@ -76,6 +94,11 @@
  
          if (chunk != null)
          {
@@ -56,7 +58,7 @@
              chunk.field_189550_d = false;
          }
  
-@@ -93,9 +114,17 @@
+@@ -93,9 +116,17 @@
  
              if (chunk != null)
              {
@@ -74,7 +76,7 @@
              }
          }
  
-@@ -113,6 +142,11 @@
+@@ -113,6 +144,11 @@
              try
              {
                  chunk = this.field_186029_c.func_185932_a(p_186025_1_, p_186025_2_);
@@ -86,7 +88,7 @@
              }
              catch (Throwable throwable)
              {
-@@ -123,7 +157,7 @@
+@@ -123,7 +159,7 @@
                  crashreportcategory.func_71507_a("Generator", this.field_186029_c);
                  throw new ReportedException(crashreport);
              }
@@ -95,7 +97,7 @@
              this.field_73244_f.put(i, chunk);
              chunk.func_76631_c();
              chunk.func_186030_a(this, this.field_186029_c);
-@@ -185,6 +219,8 @@
+@@ -185,6 +221,8 @@
  
      public boolean func_186027_a(boolean p_186027_1_)
      {
@@ -104,7 +106,7 @@
          int i = 0;
          List<Chunk> list = Lists.newArrayList(this.field_73244_f.values());
  
-@@ -224,6 +260,10 @@
+@@ -224,6 +262,10 @@
          {
              if (!this.field_73248_b.isEmpty())
              {
@@ -115,14 +117,44 @@
                  Iterator<Long> iterator = this.field_73248_b.iterator();
  
                  for (int i = 0; i < 100 && iterator.hasNext(); iterator.remove())
-@@ -238,8 +278,14 @@
+@@ -231,15 +273,43 @@
+                     Long olong = iterator.next();
+                     Chunk chunk = (Chunk)this.field_73244_f.get(olong);
+ 
+-                    if (chunk != null && chunk.field_189550_d)
++                    if (chunk != null /*&& chunk.unloadQueued*/) // CM: moved check below
+                     {
++                        if (chunk.field_189550_d) {
+                         chunk.func_76623_d();
+                         this.func_73242_b(chunk);
                          this.func_73243_a(chunk);
                          this.field_73244_f.remove(olong);
                          ++i;
-+                     
++
 +                    	// ChunkLogger - 0x-CARPET
 +                        if(CarpetClientChunkLogger.logger.enabled) {
 +                            CarpetClientChunkLogger.logger.log(this.field_73251_h,chunk.field_76635_g,chunk.field_76647_h,CarpetClientChunkLogger.Event.UNLOADING);
++                        }
++                        } else if (CarpetSettings.whereToChunkSavestate.canUnloadNearPlayers) {
++                            //noinspection ConstantConditions
++                            if (CarpetSettings.whereToChunkSavestate == CarpetSettings.WhereToChunkSavestate.everywhere
++                                    || !field_73251_h.func_175661_b(Entity.class, player -> player.field_70176_ah == chunk.field_76635_g && player.field_70164_aj == chunk.field_76647_h).isEmpty()) {
++                                // Getting the chunk size is incredibly inefficient, but it's better than unloading and reloading the chunk
++                                if ((UnloadOrder.getSavedChunkSize(chunk) + 5) / 4096 + 1 >= 256) {
++                                    chunk.func_76623_d();
++                                    //this.saveChunkData(chunk); no point saving the chunk data, we know that won't work
++                                    this.func_73243_a(chunk);
++                                    this.field_73244_f.remove(olong);
++                                    //++i; don't break stuff
++                                    Chunk newChunk = this.func_186028_c(chunk.field_76635_g, chunk.field_76647_h);
++                                    PlayerChunkMapEntry pcmEntry = field_73251_h.field_73063_M.func_187301_b(chunk.field_76635_g, chunk.field_76647_h);
++                                    if (pcmEntry != null) {
++                                        pcmEntry.field_187286_f = newChunk;
++                                        pcmEntry.field_187290_j = false;
++                                        pcmEntry.func_187272_b();
++                                    }
++                                }
++                            }
 +                        }
                      }
                  }
@@ -130,7 +162,7 @@
              }
  
              this.field_73247_e.func_75817_a();
-@@ -283,9 +329,17 @@
+@@ -283,9 +353,17 @@
      {
          return this.field_73244_f.containsKey(ChunkPos.func_77272_a(p_73149_1_, p_73149_2_));
      }

--- a/patches/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -117,7 +117,7 @@
                  Iterator<Long> iterator = this.field_73248_b.iterator();
  
                  for (int i = 0; i < 100 && iterator.hasNext(); iterator.remove())
-@@ -231,15 +273,43 @@
+@@ -231,15 +273,45 @@
                      Long olong = iterator.next();
                      Chunk chunk = (Chunk)this.field_73244_f.get(olong);
  
@@ -138,7 +138,7 @@
 +                        } else if (CarpetSettings.whereToChunkSavestate.canUnloadNearPlayers) {
 +                            //noinspection ConstantConditions
 +                            if (CarpetSettings.whereToChunkSavestate == CarpetSettings.WhereToChunkSavestate.everywhere
-+                                    || !field_73251_h.func_175661_b(Entity.class, player -> player.field_70176_ah == chunk.field_76635_g && player.field_70164_aj == chunk.field_76647_h).isEmpty()) {
++                                    || field_73251_h.func_175661_b(Entity.class, player -> player.field_70176_ah == chunk.field_76635_g && player.field_70164_aj == chunk.field_76647_h).isEmpty()) {
 +                                // Getting the chunk size is incredibly inefficient, but it's better than unloading and reloading the chunk
 +                                if ((UnloadOrder.getSavedChunkSize(chunk) + 5) / 4096 + 1 >= 256) {
 +                                    chunk.func_76623_d();
@@ -147,6 +147,8 @@
 +                                    this.field_73244_f.remove(olong);
 +                                    //++i; don't break stuff
 +                                    Chunk newChunk = this.func_186028_c(chunk.field_76635_g, chunk.field_76647_h);
++                                    if (newChunk != null)
++                                        newChunk.func_150804_b(true);
 +                                    PlayerChunkMapEntry pcmEntry = field_73251_h.field_73063_M.func_187301_b(chunk.field_76635_g, chunk.field_76647_h);
 +                                    if (pcmEntry != null) {
 +                                        pcmEntry.field_187286_f = newChunk;
@@ -162,7 +164,7 @@
              }
  
              this.field_73247_e.func_75817_a();
-@@ -283,9 +353,17 @@
+@@ -283,9 +355,17 @@
      {
          return this.field_73244_f.containsKey(ChunkPos.func_77272_a(p_73149_1_, p_73149_2_));
      }


### PR DESCRIPTION
Adds a new carpet rule, `whereToChunkSavestate`, which can allow the game to revert to a chunk savestate even when there is a player nearby (allows you to see the chunk savestate occur).
Usecase: samnrad wants to make his virus flying machine, I guess there are probably other usecases too.

`whereToChunkSavestate`:
- `unload` - only when a chunk is unloading (vanilla behaviour)
- `everywhere_except_players` - in every chunk except chunks that a player is directly standing in.
- `everywhere` - every chunk is eligible.

**Potential problems and how I solved them:**
**Problem**: Chunks near players are not normally added to the `droppedChunksSet` inside `ChunkProviderServer`.
**Solution**: When this rule is enabled, chunks nearby players are added to this set, but then immediately have their `unloadQueued` flag set to false, which means they are still in the set, but will not be unloaded (except with our modification, see below), and will not count towards the 100 chunk count when being removed from the `droppedChunksSet`.
**Problem**: if this rule is disabled during an autosave, chunks near the player may end up being permanently unloaded.
**Solution**: this was initially going to be a problem, but with `unloadQueued` set to false, if the rule is disabled, then the vanilla code will quietly remove this chunk from `droppedChunksSet` without counting it.
**Problem**: Contraptions may be unloaded that are supposed to be protected by a nearby player or a permaloader.
**Solution**: This code first checks whether a chunk is oversized before unloading and reloading it. If it is not oversized, nothing will happen.
**Problem**: How about adding an option to fix chunk savestating too?
**Solution**: I attempted this, and I now appreciate why it took so long for even PaperMC to fix it. It would take a lot more thought and time, so I didn't implement it in this PR.