### PR TITLE
add gradle task run, which runs the server using the src folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,9 +76,10 @@ sourceSets {
 		}
 	}
 }
-File runningDir = new File('build/run/')
+File runningDir = new File('run/')
 runningDir.mkdirs()
 tasks.run.workingDir = runningDir
+tasks.run.args = ['nogui']
 // ForgeGradle settings
 minecraft
 {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
+apply plugin: 'application'
 def patcher_plugin = plugins.apply 'net.minecraftforge.gradle.patcher'
 apply plugin: 'de.undercouch.download'
 apply plugin: "com.dorongold.task-tree" // For debug purposes
@@ -67,7 +68,17 @@ allprojects {
 	}
 	configurations.compile.extendsFrom configurations.forgeGradleMcDeps
 }
-
+sourceSets {
+	main {
+		java {
+			srcDirs = ['src']
+			mainClassName = 'net.minecraft.server.MinecraftServer'
+		}
+	}
+}
+File runningDir = new File('build/run/')
+runningDir.mkdirs()
+tasks.run.workingDir = runningDir
 // ForgeGradle settings
 minecraft
 {


### PR DESCRIPTION
Adds new `gradle run` command that runs the server. This allows for easy debugging and testing directly using Gradle.