### PR TITLE
Fixes comparator powered state not updating properly

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -697,6 +697,9 @@ public class CarpetSettings
     @Rule(desc = "Fixes player position truncation causing chunks to load with one block offset to chunk boarders in negative coordinates.", category = FIX)
     public static boolean playerChunkLoadingFix = false;
 
+    @Rule(desc = "Fixes comparator powered state not updating correctly from power level 15.", category = FIX)
+    public static boolean ComparatorPowerFix;
+
     // ===== FEATURES ===== //
 
     @Rule(desc = "Players drop there skulls when blown up by charged creepers.", category = FEATURE)

--- a/patches/net/minecraft/block/BlockRedstoneComparator.java.patch
+++ b/patches/net/minecraft/block/BlockRedstoneComparator.java.patch
@@ -8,16 +8,16 @@
  import java.util.List;
  import java.util.Random;
  import javax.annotation.Nullable;
-@@ -33,6 +34,9 @@
+@@ -32,6 +33,9 @@
+ import net.minecraft.util.text.translation.I18n;
  import net.minecraft.world.IBlockAccess;
  import net.minecraft.world.World;
- 
++import carpet.CarpetSettings;
 +import carpet.logging.LoggerRegistry;
 +import carpet.logging.logHelpers.InstantComparators;
-+
+ 
  public class BlockRedstoneComparator extends BlockRedstoneDiode implements ITileEntityProvider
  {
-     public static final PropertyBool field_176464_a = PropertyBool.func_177716_a("powered");
 @@ -60,7 +64,7 @@
          return new ItemStack(Items.field_151132_bS);
      }
@@ -27,7 +27,43 @@
      {
          return 2;
      }
-@@ -206,8 +210,32 @@
+@@ -101,7 +105,7 @@
+     {
+         int i = this.func_176397_f(p_176404_1_, p_176404_2_, p_176404_3_);
+ 
+-        if (i >= 15)
++        if (i >= 15 && !CarpetSettings.ComparatorPowerFix)
+         {
+             return true;
+         }
+@@ -113,13 +117,24 @@
+         {
+             int j = this.func_176407_c(p_176404_1_, p_176404_2_, p_176404_3_);
+ 
+-            if (j == 0)
++            if (!CarpetSettings.ComparatorPowerFix)
+             {
++                if (j == 0)
++                {
++                    return true;
++                }
++                else
++                {
++                    return i >= j;
++                }
++            }
++            else if (i > j)
++            {
+                 return true;
+             }
+             else
+             {
+-                return i >= j;
++                return i == j && p_176404_3_.func_177229_b(field_176463_b) == BlockRedstoneComparator.Mode.COMPARE;
+             }
+         }
+     }
+@@ -206,8 +221,32 @@
                  {
                      p_176398_1_.func_175654_a(p_176398_2_, this, 2, 0);
                  }
@@ -60,7 +96,7 @@
      }
  
      private void func_176462_k(World p_176462_1_, BlockPos p_176462_2_, IBlockState p_176462_3_)
-@@ -249,6 +277,22 @@
+@@ -249,6 +288,22 @@
          }
  
          this.func_176462_k(p_180650_1_, p_180650_2_, p_180650_3_);


### PR DESCRIPTION
Ported the fix to this bug: https://bugs.mojang.com/browse/MC-12211
Using the vanilla fix as implemented from 1.15_pre-1 and onwards.