### PR TITLE
Improved Chunk Debug

### DIFF
--- a/carpetmodSrc/carpet/utils/LRUCache.java
+++ b/carpetmodSrc/carpet/utils/LRUCache.java
@@ -1,0 +1,18 @@
+package carpet.utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LRUCache<K, V> extends LinkedHashMap<K, V> {
+    private final int capacity;
+
+    public LRUCache(int capacity) {
+        super(capacity + 1, 1f, true);
+        this.capacity = capacity;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+        return size() > capacity;
+    }
+}

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -422,7 +422,7 @@
              for (BlockEventData blockeventdata : this.field_147490_S[i])
              {
 +                if(carpet.carpetclient.CarpetClientChunkLogger.logger.enabled)
-+                    carpet.carpetclient.CarpetClientChunkLogger.setReason("Queued block event: " + blockeventdata.func_151337_f().func_176223_P());
++                    carpet.carpetclient.CarpetClientChunkLogger.setReason("Queued block event: " + blockeventdata);
                  if (this.func_147485_a(blockeventdata))
                  {
                      this.field_73061_a.func_184103_al().func_148543_a((EntityPlayer)null, (double)blockeventdata.func_180328_a().func_177958_n(), (double)blockeventdata.func_180328_a().func_177956_o(), (double)blockeventdata.func_180328_a().func_177952_p(), 64.0D, this.field_73011_w.func_186058_p().func_186068_a(), new SPacketBlockAction(blockeventdata.func_180328_a(), blockeventdata.func_151337_f(), blockeventdata.func_151339_d(), blockeventdata.func_151338_e()));


### PR DESCRIPTION
Fixes a memory leak by using a (bounded) LRU cache for keeping track of interned strings.

Also includes a small change to improve the info logged for block events (now includes for example position and doesn't pretend it's the default state)