### PR TITLE
Added functionality for fake players to hold down right click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 *.ipr
 *.iws
 
+# cscope
+cscope.*
+
 # Gradle
 /build
 /.gradle

--- a/carpetmodSrc/carpet/commands/CommandPlayer.java
+++ b/carpetmodSrc/carpet/commands/CommandPlayer.java
@@ -41,7 +41,7 @@ public class CommandPlayer extends CommandCarpetBase
      */
     public String getUsage(ICommandSender sender)
     {
-        return "player <spawn|kill|stop|drop|swapHands|mount|dismount> <player_name>  OR /player <use|attack|jump> <player_name> <once|continuous|interval.. ticks>";
+        return "player <spawn|kill|stop|drop|swapHands|mount|dismount> <player_name>  OR /player <use|attack|jump> <player_name> <once|continuous|hold|interval.. ticks>";
     }
 
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
@@ -87,6 +87,8 @@ public class CommandPlayer extends CommandCarpetBase
                     player.actionPack.useOnce();
                 if (option.equalsIgnoreCase("continuous"))
                     player.actionPack.setUseForever();
+                if (option.equalsIgnoreCase("hold"))
+		    player.actionPack.holdUse();
                 if (option.equalsIgnoreCase("interval") && interval > 1)
                     player.actionPack.setUse(interval, 0);
             }
@@ -94,7 +96,7 @@ public class CommandPlayer extends CommandCarpetBase
             {
                 if (option.equalsIgnoreCase("once"))
                     player.actionPack.attackOnce();
-                if (option.equalsIgnoreCase("continuous"))
+                if (option.equalsIgnoreCase("continuous") || option.equalsIgnoreCase("hold"))
                     player.actionPack.setAttackForever();
                 if (option.equalsIgnoreCase("interval") && interval > 1)
                     player.actionPack.setAttack(interval, 0);
@@ -103,7 +105,7 @@ public class CommandPlayer extends CommandCarpetBase
             {
                 if (option.equalsIgnoreCase("once"))
                     player.actionPack.jumpOnce();
-                if (option.equalsIgnoreCase("continuous"))
+                if (option.equalsIgnoreCase("continuous") || option.equalsIgnoreCase("hold"))
                     player.actionPack.setJumpForever();
                 if (option.equalsIgnoreCase("interval") && interval > 1)
                     player.actionPack.setJump(interval, 0);
@@ -315,7 +317,7 @@ public class CommandPlayer extends CommandCarpetBase
         if (args.length == 3 && (args[1].matches("^(?:use|attack|jump)$")))
         {
             //currently for all, needs to be restricted for Fake plaeyrs
-            return getListOfStringsMatchingLastWord(args, "once","continuous","interval");
+            return getListOfStringsMatchingLastWord(args, "once","continuous", "hold", "interval");
         }
         if (args.length == 4 && (args[1].equalsIgnoreCase("interval")))
         {

--- a/carpetmodSrc/carpet/commands/CommandPlayer.java
+++ b/carpetmodSrc/carpet/commands/CommandPlayer.java
@@ -41,7 +41,7 @@ public class CommandPlayer extends CommandCarpetBase
      */
     public String getUsage(ICommandSender sender)
     {
-        return "player <spawn|kill|stop|drop|swapHands|mount|dismount> <player_name>  OR /player <use|attack|jump> <player_name> <once|continuous|hold|interval.. ticks>";
+        return "player <player_name> <spawn|kill|stop|drop|swapHands|mount|dismount>   OR /player <player_name> <use|attack|jump> <once|continuous|interval.. ticks>";
     }
 
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
@@ -78,7 +78,7 @@ public class CommandPlayer extends CommandCarpetBase
                 option = args[2];
                 if (args.length > 3 && option.equalsIgnoreCase("interval"))
                 {
-                    interval = parseInt(args[3],2,72000);
+                    interval = parseInt(args[3],1,72000);
                 }
             }
             if (action.equalsIgnoreCase("use"))
@@ -87,27 +87,25 @@ public class CommandPlayer extends CommandCarpetBase
                     player.actionPack.useOnce();
                 if (option.equalsIgnoreCase("continuous"))
                     player.actionPack.setUseForever();
-                if (option.equalsIgnoreCase("hold"))
-		    player.actionPack.holdUse();
-                if (option.equalsIgnoreCase("interval") && interval > 1)
+                if (option.equalsIgnoreCase("interval") && interval > 0)
                     player.actionPack.setUse(interval, 0);
             }
             if (action.equalsIgnoreCase("attack"))
             {
                 if (option.equalsIgnoreCase("once"))
                     player.actionPack.attackOnce();
-                if (option.equalsIgnoreCase("continuous") || option.equalsIgnoreCase("hold"))
+                if (option.equalsIgnoreCase("continuous"))
                     player.actionPack.setAttackForever();
-                if (option.equalsIgnoreCase("interval") && interval > 1)
+                if (option.equalsIgnoreCase("interval") && interval > 0)
                     player.actionPack.setAttack(interval, 0);
             }
             if (action.equalsIgnoreCase("jump"))
             {
                 if (option.equalsIgnoreCase("once"))
                     player.actionPack.jumpOnce();
-                if (option.equalsIgnoreCase("continuous") || option.equalsIgnoreCase("hold"))
+                if (option.equalsIgnoreCase("continuous"))
                     player.actionPack.setJumpForever();
-                if (option.equalsIgnoreCase("interval") && interval > 1)
+                if (option.equalsIgnoreCase("interval") && interval > 0)
                     player.actionPack.setJump(interval, 0);
             }
             return;
@@ -317,7 +315,7 @@ public class CommandPlayer extends CommandCarpetBase
         if (args.length == 3 && (args[1].matches("^(?:use|attack|jump)$")))
         {
             //currently for all, needs to be restricted for Fake plaeyrs
-            return getListOfStringsMatchingLastWord(args, "once","continuous", "hold", "interval");
+            return getListOfStringsMatchingLastWord(args, "once","continuous", "interval");
         }
         if (args.length == 4 && (args[1].equalsIgnoreCase("interval")))
         {

--- a/carpetmodSrc/carpet/helpers/EntityPlayerActionPack.java
+++ b/carpetmodSrc/carpet/helpers/EntityPlayerActionPack.java
@@ -40,6 +40,7 @@ public class EntityPlayerActionPack
     private int attackCooldown;
 
     private boolean doesUse;
+    private boolean holdingUse;
     private int useInterval;
     private int useCooldown;
 
@@ -69,6 +70,7 @@ public class EntityPlayerActionPack
         attackCooldown = other.attackCooldown;
 
         doesUse = other.doesUse;
+	holdingUse = other.holdingUse;
         useInterval = other.useInterval;
         useCooldown = other.useCooldown;
 
@@ -108,6 +110,7 @@ public class EntityPlayerActionPack
             return this;
         }
         this.doesUse = true;
+	this.holdingUse = false;
         this.useInterval = interval;
         this.useCooldown = interval+offset;
         return this;
@@ -115,9 +118,18 @@ public class EntityPlayerActionPack
     public EntityPlayerActionPack setUseForever()
     {
         this.doesUse = true;
+	this.holdingUse = false;
         this.useInterval = 1;
         this.useCooldown = 1;
         return this;
+    }
+    public EntityPlayerActionPack holdUse()
+    {
+	this.doesUse = true;
+	this.holdingUse = true;
+	this.useInterval = 4;
+	this.useCooldown = 4;
+	return this;
     }
     public EntityPlayerActionPack setAttackForever()
     {
@@ -225,6 +237,7 @@ public class EntityPlayerActionPack
     public EntityPlayerActionPack stop()
     {
         this.doesUse = false;
+	this.holdingUse = false;
         this.doesAttack = false;
         this.doesJump = false;
         resetBlockRemoving();
@@ -296,8 +309,15 @@ public class EntityPlayerActionPack
 
         if (doesUse && (--useCooldown)==0)
         {
-            useCooldown = useInterval;
             used  = useOnce();
+	    if (holdingUse && !used)
+	    {
+		useCooldown = 1;
+	    }
+	    else
+	    {
+		useCooldown = useInterval;
+	    }
         }
         if (doesAttack)
         {

--- a/carpetmodSrc/carpet/helpers/EntityPlayerActionPack.java
+++ b/carpetmodSrc/carpet/helpers/EntityPlayerActionPack.java
@@ -40,7 +40,7 @@ public class EntityPlayerActionPack
     private int attackCooldown;
 
     private boolean doesUse;
-    private boolean holdingUse;
+    private boolean useForever;
     private int useInterval;
     private int useCooldown;
 
@@ -70,7 +70,7 @@ public class EntityPlayerActionPack
         attackCooldown = other.attackCooldown;
 
         doesUse = other.doesUse;
-	holdingUse = other.holdingUse;
+	useForever = other.useForever;
         useInterval = other.useInterval;
         useCooldown = other.useCooldown;
 
@@ -110,7 +110,7 @@ public class EntityPlayerActionPack
             return this;
         }
         this.doesUse = true;
-	this.holdingUse = false;
+	this.useForever = false;
         this.useInterval = interval;
         this.useCooldown = interval+offset;
         return this;
@@ -118,18 +118,10 @@ public class EntityPlayerActionPack
     public EntityPlayerActionPack setUseForever()
     {
         this.doesUse = true;
-	this.holdingUse = false;
-        this.useInterval = 1;
-        this.useCooldown = 1;
+	this.useForever = true;
+        this.useInterval = 4;
+        this.useCooldown = 4;
         return this;
-    }
-    public EntityPlayerActionPack holdUse()
-    {
-	this.doesUse = true;
-	this.holdingUse = true;
-	this.useInterval = 4;
-	this.useCooldown = 4;
-	return this;
     }
     public EntityPlayerActionPack setAttackForever()
     {
@@ -237,7 +229,7 @@ public class EntityPlayerActionPack
     public EntityPlayerActionPack stop()
     {
         this.doesUse = false;
-	this.holdingUse = false;
+	this.useForever = false;
         this.doesAttack = false;
         this.doesJump = false;
         resetBlockRemoving();
@@ -310,7 +302,7 @@ public class EntityPlayerActionPack
         if (doesUse && (--useCooldown)==0)
         {
             used  = useOnce();
-	    if (holdingUse && !used)
+	    if (useForever && !used)
 	    {
 		useCooldown = 1;
 	    }

--- a/carpetmodSrc/carpet/helpers/TickSpeed.java
+++ b/carpetmodSrc/carpet/helpers/TickSpeed.java
@@ -179,6 +179,6 @@ public class TickSpeed
     }
 
     public static double getTPS() {
-        return 1000.0D / Math.max((time_warp_start_time != 0) ? 0.0 : TickSpeed.mspt, getMSPT());
+        return 1000.0D / Math.max((time_warp_start_time != 0) ? 0.0 : TickSpeed.mspt, mspt);
     }
 }

--- a/carpetmodSrc/carpet/helpers/TickSpeed.java
+++ b/carpetmodSrc/carpet/helpers/TickSpeed.java
@@ -179,6 +179,6 @@ public class TickSpeed
     }
 
     public static double getTPS() {
-        return 1000.0D / Math.max((time_warp_start_time != 0) ? 0.0 : TickSpeed.mspt, mspt);
+        return 1000.0D / Math.max((time_warp_start_time != 0) ? 0.0 : TickSpeed.mspt, getMSPT());
     }
 }


### PR DESCRIPTION
Changed `/player <player_name> use continuous` to more accurately imitate a real player holding right click (Attempts to right click every tick, with a 4 gametick cooldown after each successful attempt before trying again)

The old `use continuous` behavior can now be achieved through `/player <player_name> use interval 1`

`interval 1` option is now allowed for `use`, `attack` and `jump`