### PR TITLE
Emerald ore simulates an update suppressor

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -147,7 +147,7 @@ public class CarpetSettings
 
     // ===== CREATIVE TOOLS ===== //
 
-    @Rule(desc = "Emerald ore receiving a block update, will throw a StackOverflowError, simulating an update suppressor.", category = CREATIVE)
+    @Rule(desc = "Emerald ore receiving a block update will throw a StackOverflowError, simulating an update suppressor.", category = CREATIVE)
     public static boolean oreUpdateSuppressor = false;
 
     @Rule(desc = "Makes update carpet public for all users.", category = CREATIVE)

--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -147,6 +147,9 @@ public class CarpetSettings
 
     // ===== CREATIVE TOOLS ===== //
 
+    @Rule(desc = "Emerald ore receiving a block update, will throw a StackOverflowError, simulating an update supressor.", category = CREATIVE)
+    public static boolean oreUpdateSupressor = false;
+
     @Rule(desc = "Makes update carpet public for all users.", category = CREATIVE)
     public static boolean updateCarpetAll;
 

--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -147,8 +147,8 @@ public class CarpetSettings
 
     // ===== CREATIVE TOOLS ===== //
 
-    @Rule(desc = "Emerald ore receiving a block update, will throw a StackOverflowError, simulating an update supressor.", category = CREATIVE)
-    public static boolean oreUpdateSupressor = false;
+    @Rule(desc = "Emerald ore receiving a block update, will throw a StackOverflowError, simulating an update suppressor.", category = CREATIVE)
+    public static boolean oreUpdateSuppressor = false;
 
     @Rule(desc = "Makes update carpet public for all users.", category = CREATIVE)
     public static boolean updateCarpetAll;

--- a/patches/net/minecraft/block/BlockOre.java.patch
+++ b/patches/net/minecraft/block/BlockOre.java.patch
@@ -1,22 +1,30 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockOre.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockOre.java
-@@ -1,6 +1,8 @@
+@@ -1,6 +1,7 @@
  package net.minecraft.block;
  
  import java.util.Random;
 +
-+import carpet.CarpetSettings;
  import net.minecraft.block.material.MapColor;
  import net.minecraft.block.material.Material;
  import net.minecraft.block.state.IBlockState;
-@@ -27,6 +29,14 @@
+@@ -14,6 +15,8 @@
+ import net.minecraft.util.math.MathHelper;
+ import net.minecraft.world.World;
+ 
++import carpet.CarpetSettings;
++
+ public class BlockOre extends Block
+ {
+     public BlockOre()
+@@ -27,6 +30,14 @@
          this.func_149647_a(CreativeTabs.field_78030_b);
      }
  
 +    //CM start
 +    public void func_189540_a(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos){
 +        if (CarpetSettings.oreUpdateSuppressor && this == Blocks.field_150412_bA){
-+            throw new StackOverflowError();
++            throw new StackOverflowError("Carpet-triggered update suppression");
 +        }
 +    }
 +    //CM end

--- a/patches/net/minecraft/block/BlockOre.java.patch
+++ b/patches/net/minecraft/block/BlockOre.java.patch
@@ -15,7 +15,7 @@
  
 +    //CM start
 +    public void func_189540_a(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos){
-+        if (CarpetSettings.oreUpdateSupressor && this == Blocks.field_150412_bA){
++        if (CarpetSettings.oreUpdateSuppressor && this == Blocks.field_150412_bA){
 +            throw new StackOverflowError();
 +        }
 +    }

--- a/patches/net/minecraft/block/BlockOre.java.patch
+++ b/patches/net/minecraft/block/BlockOre.java.patch
@@ -1,0 +1,26 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockOre.java
++++ ../src-work/minecraft/net/minecraft/block/BlockOre.java
+@@ -1,6 +1,8 @@
+ package net.minecraft.block;
+ 
+ import java.util.Random;
++
++import carpet.CarpetSettings;
+ import net.minecraft.block.material.MapColor;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+@@ -27,6 +29,14 @@
+         this.func_149647_a(CreativeTabs.field_78030_b);
+     }
+ 
++    //CM start
++    public void func_189540_a(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos){
++        if (CarpetSettings.oreUpdateSupressor && this == Blocks.field_150412_bA){
++            throw new StackOverflowError();
++        }
++    }
++    //CM end
++
+     public Item func_180660_a(IBlockState p_180660_1_, Random p_180660_2_, int p_180660_3_)
+     {
+         if (this == Blocks.field_150365_q)


### PR DESCRIPTION
Having to build rail lines all the time when testing update suppression is mega annoying. So having a block to do the same is very useful.