### PR TITLE
Expand optimizedTileEntityRemoval to include self-removed tile entities

### DIFF
--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -339,7 +339,7 @@
                  }
                  catch (Throwable throwable1)
                  {
-@@ -1437,22 +1588,38 @@
+@@ -1437,31 +1588,50 @@
  
                  if (entity2.field_70175_ag && this.func_175680_a(l1, i2, true))
                  {
@@ -380,7 +380,11 @@
              this.field_147483_b.clear();
          }
  
-@@ -1462,6 +1629,7 @@
+         this.field_147481_N = true;
+         Iterator<TileEntity> iterator = this.field_175730_i.iterator();
+ 
++        Set<TileEntity> tileEntitiesRemovedInTick = new HashSet<>(); // CM
++
          while (iterator.hasNext())
          {
              TileEntity tileentity = iterator.next();
@@ -388,7 +392,7 @@
  
              if (!tileentity.func_145837_r() && tileentity.func_145830_o())
              {
-@@ -1471,12 +1639,14 @@
+@@ -1471,12 +1641,14 @@
                  {
                      try
                      {
@@ -409,15 +413,34 @@
                      }
                      catch (Throwable throwable)
                      {
-@@ -1498,6 +1668,7 @@
+@@ -1490,16 +1662,26 @@
+ 
+             if (tileentity.func_145837_r())
+             {
++                if (CarpetSettings.optimizedTileEntityRemoval) {
++                    tileEntitiesRemovedInTick.add(tileentity);
++                } else {
+                 iterator.remove();
+                 this.field_147482_g.remove(tileentity);
++                }
+ 
+                 if (this.func_175667_e(tileentity.func_174877_v()))
+                 {
                      this.func_175726_f(tileentity.func_174877_v()).func_177425_e(tileentity.func_174877_v());
                  }
              }
 +            CarpetProfiler.end_current_entity_section();
          }
  
++        if (CarpetSettings.optimizedTileEntityRemoval) {
++            this.field_175730_i.removeAll(tileEntitiesRemovedInTick);
++            this.field_147482_g.removeAll(tileEntitiesRemovedInTick);
++        }
++
          this.field_147481_N = false;
-@@ -1528,6 +1699,8 @@
+         this.field_72984_F.func_76318_c("pendingBlockEntities");
+ 
+@@ -1528,6 +1710,8 @@
  
              this.field_147484_a.clear();
          }
@@ -426,7 +449,7 @@
  
          this.field_72984_F.func_76319_b();
          this.field_72984_F.func_76319_b();
-@@ -1648,7 +1821,8 @@
+@@ -1648,7 +1832,8 @@
                  this.func_72964_e(p_72866_1_.field_70176_ah, p_72866_1_.field_70164_aj).func_76608_a(p_72866_1_, p_72866_1_.field_70162_ai);
              }
  
@@ -436,7 +459,7 @@
              {
                  p_72866_1_.field_70175_ag = false;
              }
-@@ -1670,7 +1844,11 @@
+@@ -1670,7 +1855,11 @@
                  }
                  else
                  {
@@ -449,7 +472,7 @@
                  }
              }
          }
-@@ -1689,7 +1867,7 @@
+@@ -1689,7 +1878,7 @@
          {
              Entity entity4 = list.get(j2);
  
@@ -458,7 +481,7 @@
              {
                  return false;
              }
-@@ -2153,6 +2331,16 @@
+@@ -2153,6 +2342,16 @@
                          {
                              this.field_72986_A.func_76090_f(this.field_73012_v.nextInt(168000) + 12000);
                          }
@@ -475,7 +498,7 @@
                      }
                      else
                      {
-@@ -2177,6 +2365,16 @@
+@@ -2177,6 +2376,16 @@
                          {
                              this.field_72986_A.func_76080_g(this.field_73012_v.nextInt(168000) + 12000);
                          }
@@ -492,7 +515,7 @@
                      }
                      else
                      {
-@@ -2387,6 +2585,11 @@
+@@ -2387,6 +2596,11 @@
  
      public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
      {
@@ -504,7 +527,7 @@
          if (!this.func_175648_a(p_180500_2_, 17, false))
          {
              return false;
-@@ -2699,7 +2902,8 @@
+@@ -2699,7 +2913,8 @@
          IBlockState iblockstate1 = this.func_180495_p(p_190527_2_);
          AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
  
@@ -514,7 +537,7 @@
          {
              return false;
          }
-@@ -3267,30 +3471,41 @@
+@@ -3267,30 +3482,41 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -571,7 +594,7 @@
      }
  
      public DifficultyInstance func_175649_E(BlockPos p_175649_1_)
-@@ -3361,4 +3576,128 @@
+@@ -3361,4 +3587,128 @@
      {
          return null;
      }


### PR DESCRIPTION
This enables the tile entity removal optimization for tile entities that set the `tileEntityInvalid` flag in their `update()` method, like piston tile entities do.

Example workload: 2No's quarry on SciCraft with lots of chests in the spawn chunks
rule off: 195ms
rule on: 160ms