### PR TITLE
feat(commands): Change dimensions on /tp

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -225,6 +225,9 @@ public class CarpetSettings
     @Rule(desc = "Enables controlable TNT jump angle RNG for debuging.", category = TNT)
     public static boolean TNTAdjustableRandomAngle;
 
+    @Rule(desc = "/tp will teleport the players across dimensions", category = CREATIVE)
+    public static boolean tpAcrossDimensions = true;
+
     @Rule(desc = "Allows to place blocks in different orientations. Requires Carpet Client", category = CREATIVE, extra = {
             "Also prevents rotations upon placement of dispensers and furnaces",
             "when placed into a world by commands"

--- a/carpetmodSrc/carpet/helpers/TeleportHelper.java
+++ b/carpetmodSrc/carpet/helpers/TeleportHelper.java
@@ -1,0 +1,41 @@
+package carpet.helpers;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.SPacketRespawn;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
+
+public class TeleportHelper {
+
+    public static void changeDimensions(EntityPlayerMP player, EntityPlayerMP target){
+        // Adapted from spectator teleport code (NetHandlerPlayServer::handleSpectate)
+        double x = target.posX;
+        double y = target.posY;
+        double z = target.posZ;
+        MinecraftServer server = player.getServer();
+        assert server != null;
+
+        WorldServer worldFrom = (WorldServer) player.world;
+        WorldServer worldTo = (WorldServer) target.world;
+        int dimension = worldTo.provider.getDimensionType().getId();
+        player.dimension = dimension;
+
+        player.connection.sendPacket(new SPacketRespawn(dimension, worldFrom.getDifficulty(), worldFrom.getWorldInfo().getTerrainType(), player.interactionManager.getGameType()));
+        server.getPlayerList().updatePermissionLevel(player);
+        worldFrom.removeEntityDangerously(player);
+        player.isDead = false;
+        player.setLocationAndAngles(x, y, z, (float) target.rotationYaw, (float) target.rotationPitch);
+
+        worldFrom.updateEntityWithOptionalForce(player, false);
+        worldTo.spawnEntity(player);
+        worldTo.updateEntityWithOptionalForce(player, false);
+
+        player.setWorld(worldTo);
+        server.getPlayerList().preparePlayer(player, worldFrom);
+
+        player.setPositionAndUpdate(x, y, z);
+        player.interactionManager.setWorld(worldTo);
+        server.getPlayerList().updateTimeAndWeatherForPlayer(player, worldTo);
+        server.getPlayerList().syncPlayerInventory(player);
+    }
+}

--- a/patches/net/minecraft/command/CommandTP.java.patch
+++ b/patches/net/minecraft/command/CommandTP.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/command/CommandTP.java
 +++ ../src-work/minecraft/net/minecraft/command/CommandTP.java
-@@ -13,6 +13,10 @@
+@@ -5,6 +5,8 @@
+ import java.util.List;
+ import java.util.Set;
+ import javax.annotation.Nullable;
++
++import carpet.helpers.TeleportHelper;
+ import net.minecraft.entity.Entity;
+ import net.minecraft.entity.EntityLivingBase;
+ import net.minecraft.entity.player.EntityPlayerMP;
+@@ -13,6 +15,10 @@
  import net.minecraft.util.math.BlockPos;
  import net.minecraft.util.math.MathHelper;
  
@@ -11,7 +20,7 @@
  public class CommandTP extends CommandBase
  {
      public String func_71517_b()
-@@ -38,6 +42,17 @@
+@@ -38,6 +44,17 @@
          }
          else
          {
@@ -29,3 +38,18 @@
              int i = 0;
              Entity entity;
  
+@@ -73,7 +90,13 @@
+             else
+             {
+                 Entity entity1 = func_184885_b(p_184881_1_, p_184881_2_, p_184881_3_[p_184881_3_.length - 1]);
+-
++                // CM
++                if(CarpetSettings.tpAcrossDimensions && (entity1.field_70170_p != entity.field_70170_p)){
++                    if(entity1 instanceof EntityPlayerMP && entity instanceof EntityPlayerMP){
++                        TeleportHelper.changeDimensions((EntityPlayerMP) entity, (EntityPlayerMP) entity1);
++                    }
++                }
++                // CM END
+                 if (entity1.field_70170_p != entity.field_70170_p)
+                 {
+                     throw new CommandException("commands.tp.notSameDimension", new Object[0]);


### PR DESCRIPTION
When TPing to another player, if the player its in another dimension and the carpet rule `tpAcrossDimensions` its on, then the teleporting player will change dimensions to the target's one.

### How to replicate
- Spawn a bot in the overworld `/player over spawn`
- Change dimension to the nether
- Teleport to the bot `/tp over`