### PR TITLE
added removeTNTVelocity rule

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -978,6 +978,10 @@ public class CarpetSettings
 
     @Rule(desc = "Changes default tnt fuse.", category = CREATIVE, validator = "validatePositive", options = {"70", "80", "100"})
     public static int tntFuseLength = 80;
+
+    @Rule(desc = "Removes tnt applying velocity to other entities.", category = CREATIVE)
+    public static boolean removeTNTVelocity = false;
+
     // ===== API ===== //
 
     /**

--- a/carpetmodSrc/carpet/helpers/OptimizedTNT.java
+++ b/carpetmodSrc/carpet/helpers/OptimizedTNT.java
@@ -96,6 +96,11 @@ public class OptimizedTNT
 
         explosionSound++;
 
+        // CARPET-SYLKOS
+        // TNT shouldn't apply velocity to entities
+        // This also yeets all the calculations tnt does for applying velocity and damage to entities
+        if(CarpetSettings.removeTNTVelocity) return;
+
         for (int k2 = 0; k2 < entitylist.size(); ++k2) {
             Entity entity = entitylist.get(k2);
 

--- a/patches/net/minecraft/world/Explosion.java.patch
+++ b/patches/net/minecraft/world/Explosion.java.patch
@@ -74,16 +74,22 @@
          Set<BlockPos> set = Sets.<BlockPos>newHashSet();
          int i = 16;
  
-@@ -102,7 +127,7 @@
+@@ -102,7 +127,13 @@
              }
          }
  
 -        this.field_77281_g.addAll(set);
 +        if(!CarpetSettings.explosionNoBlockDamage) this.field_77281_g.addAll(set);
++
++        // CARPET-SYLKOS
++        // TNT shouldn't apply velocity to entities
++        // This also yeets all the calculations tnt does for applying velocity and damage to entities
++        if(CarpetSettings.removeTNTVelocity) return;
++
          float f3 = this.field_77280_f * 2.0F;
          int k1 = MathHelper.func_76128_c(this.field_77284_b - (double)f3 - 1.0D);
          int l1 = MathHelper.func_76128_c(this.field_77284_b + (double)f3 + 1.0D);
-@@ -164,6 +189,14 @@
+@@ -164,6 +195,14 @@
  
      public void func_77279_a(boolean p_77279_1_)
      {
@@ -98,7 +104,7 @@
          this.field_77287_j.func_184148_a((EntityPlayer)null, this.field_77284_b, this.field_77285_c, this.field_77282_d, SoundEvents.field_187539_bB, SoundCategory.BLOCKS, 4.0F, (1.0F + (this.field_77287_j.field_73012_v.nextFloat() - this.field_77287_j.field_73012_v.nextFloat()) * 0.2F) * 0.7F);
  
          if (this.field_77280_f >= 2.0F && this.field_82755_b)
-@@ -226,6 +259,11 @@
+@@ -226,6 +265,11 @@
                  }
              }
          }


### PR DESCRIPTION
Added a carpet rule which stops TNT from applying velocity in the doExplosionA method by cutting it short before the calculation (This is the last thing the method does before ending). This will be useful for debugging TNT explosion positions without having the packets interfere with one another.