### PR TITLE
Use launcher.mojang.com instead of s3.amazonaws.com to download server.jar

### DIFF
--- a/docs/usage/install.rst
+++ b/docs/usage/install.rst
@@ -35,7 +35,7 @@ First, create a clean directory (folder). For this tutorial, we call it
 ``carpet``. There, download the vanilla jar and Carpet patch.
 
 * `Download the 1.12.2 vanilla server jar
-  <https://s3.amazonaws.com/Minecraft.Download/versions/1.12.2/minecraft_server.1.12.2.jar>`_.
+  <https://launchermeta.mojang.com/v1/packages/cfd75871c03119093d7c96a6a99f21137d00c855/1.12.2.json>`_.
 * `Download the latest Carpet patch
   <https://github.com/gnembon/carpetmod/releases/latest>`_.
 

--- a/mktest.sh
+++ b/mktest.sh
@@ -69,7 +69,7 @@ else
         cp "$GRADLE_CACHE_JAR" "$MC_JAR"
     else
         echo "Downloading server ..."
-        wget "https://s3.amazonaws.com/Minecraft.Download/versions/1.12.2/minecraft_server.1.12.2.jar" -O "$MC_JAR" || { echo "failed to download MC jar" && exit 1; }
+        wget "https://launcher.mojang.com/v1/objects/886945bfb2b978778c3a0288fd7fab09d315b25f/server.jar" -O "$MC_JAR" || { echo "failed to download MC jar" && exit 1; }
         cp "$MC_JAR" "$MC_JAR.orig"
     fi
 fi


### PR DESCRIPTION
old link: [https://s3.amazonaws.com/Minecraft.Download/versions/1.12.2/minecraft_server.1.12.2.jar](https://s3.amazonaws.com/Minecraft.Download/versions/1.12.2/minecraft_server.1.12.2.jar)

new link: [https://launchermeta.mojang.com/v1/packages/cfd75871c03119093d7c96a6a99f21137d00c855/1.12.2.json](https://launchermeta.mojang.com/v1/packages/cfd75871c03119093d7c96a6a99f21137d00c855/1.12.2.json)

I just exchanged the download link in the `mktest.sh` and in the docs.

As written [here](https://www.cnbc.com/2020/07/20/microsoft-minecraft-mojang-abandon-aws-for-azure.html), i think it's better to switch to the new `launcher.mojang.com` API.