### PR TITLE
Improve mktest.sh, add download folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.classpath
 /eclipse/
 .project
+/download/
 
 # IDEA
 /.idea

--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ In case you use different paths, you might need to modify the build script.
 This will leave a ready server jar file in your saves folder.
 
 It requires to have 7za installed in your paths
+### To run the server locally (Linux)
+Run `./mktest.sh -t -g` to run the modified server with generated patches as a localhost server. It requires `gradlew genPatches createRelease` to finish successfully.
+
+Add `-e` if you agree to the Minecraft Eula, `-D` if you want the server to use a deobfuscated jar, so you can read the names in crashlogs for example.
+Add `-k` if you don't want to clear the `test` folder for every run.
+
+If you want to specify your `JAVA_HOME`, add `JAVA_HOME=/folder/to/java` (with a space seperating the command) at the start of the command.
+
+Use `./mktest.sh --help` to view help that tells you more.
+
+It requires to have zip, unzip, and wget installed (most desktop distributions already have that).

--- a/mktest.sh
+++ b/mktest.sh
@@ -172,6 +172,9 @@ if [ "$run_server" == "1" ]; then
     echo "Starting server ..."
     runJava "$test_jar" --nogui
 
+    # remove the server jar, as the next test will copy a new one
+    rm -f "$test_jar"
+
     popd > /dev/null
 fi
 

--- a/mktest.sh
+++ b/mktest.sh
@@ -1,108 +1,178 @@
 #!/bin/sh
 
 # Parse command line args
-TEST=0
-EULA=0
 while [ $# -gt 0 ]; do
 
     key="$1"
 
     case $key in
-        -d|--download)
-            URL="$2"
-            shift
-            shift
-            ;;
-        -o|--outfile)
-            OUTFILE="$2"
-            shift
-            shift
-            ;;
-        -t|--test)
-            TEST=1
-            shift
-            ;;
-        -e|--eula)
-            EULA=1
-            shift
-            ;;
+        -d|--download)   patch_url="$2"        ; shift ;;
+        -o|--outfile)    jar_copy_to="$2"      ; shift ;;
+        -t|--test)       run_server=1                  ;;
+        -e|--eula)       eula=1                        ;;
+        -D|--deobf)      additional_deobfuscated_jar=1 ;;
+        -g|--gradle)     run_gradle=1                  ;;
+        -k|--keep)       keep_configs=1                ;;
+        -p|--properties) copy_server_properties=1      ;;
         -h|--help)
             # immediately print help
-            echo "$0 [-h] [-d URL] [-o OUTFILE] [-t] [-e]"
+            echo "$0 [-h] [-d URL] [-o OUTFILE] [-D] [-g] [-k] [-p] [-t] [-e]"
             echo " install and test Carpet patches"
             echo ""
             echo "options:"
-            echo " -h,--help            print this help and exit"
-            echo " -d,--download URL    download patches from given URL"
-            echo " -o,--outfile OUTFILE output to given file"
-            echo " -t,--test            run a test"
-            echo " -e,--eula            agree to Mojang EULA"
+            echo " -h,--help             print this help and exit"
+            echo " -d,--download URL     download patches from given URL"
+            echo " -o,--outfile OUTFILE  output to given file"
+            echo " -t,--test             run a test (run the server)"
+            echo " -e,--eula             agree to Mojang EULA (see <https://account.mojang.com/documents/minecraft_eula>)"
+            echo " -D,--deobf            create a deobfuscated jar in the build folder, and use that when to running a test"
+            echo " -g,--gradle           run gradlew to compile carpet first"
+            echo " -k,--keep             keep the world and config files of the server"
+            echo " -p,--properties       copy server.properties.bak to server.properties and replace every instance of \"BUILD\" with the output of \"date -Iseconds\""
             exit 0
-            shift
-            shift
             ;;
     esac
+    shift
 done
 
-carpet_name="carpet-1.12.2-`date +%F`.jar"
+
+project_base_dir="`pwd`"
+build_dir="$project_base_dir/build/tmp/fullRelease"
+download_dir="$project_base_dir/download"
+
+patch_zip="$project_base_dir/build/distributions/Carpetmod_dev.zip"
+patch_dir="$build_dir/patches"
+
+server_jar_backup="$server_jar.bak"
+server_jar_gradle_cache="$HOME/.gradle/caches/minecraft/net/minecraft/minecraft_server/1.12.2/minecraft_server-1.12.2.jar"
+server_jar_url="https://launcher.mojang.com/v1/objects/886945bfb2b978778c3a0288fd7fab09d315b25f/server.jar"
+
+specialsource_jar="$download_dir/SpecialSource-1.11.0-shaded.jar"
+specialsource_jar_url="https://repo.maven.apache.org/maven2/net/md-5/SpecialSource/1.11.0/SpecialSource-1.11.0-shaded.jar"
+
+mappings_file="$project_base_dir/build/tmp/reobfuscate/reobf_cls.srg"
+
+date_str="`date +%F`"
+
+carpet_jar="$project_base_dir/build//carpet-1.12.2-$date_str.jar"
+carpet_jar_deob="$project_base_dir/build/carpet-1.12.2-$date_str-dev.jar"
+
+test_dir="$project_base_dir/test"
+test_jar="$test_dir/carpet-1.12.2-$date_str.jar"
+
+function downloadIfNotHere(){
+    # $1 - the location to check for and download to
+    # $2 - the url to download from
+    # $3 - the message to print before downloading
+    # $4 - the message to print when it fails
+    mkdir -p "`dirname $1`"
+    if [ ! -f "$1" ]; then
+        echo "$3"
+        wget "$2" -O "$1" || { echo "$4" && exit 1; }
+    fi
+}
+
+function runJava(){
+    # $1 - the jar to run
+    # $@ - the arguments to pass
+    jar="$1"
+    shift
+    "$JAVA_HOME/bin/java" -jar "$jar" $@
+}
+
+function runGradle(){
+    # $@ - the gradle tasks to run
+    "$project_base_dir/gradlew" $@
+}
+
+# compile carpet with gradle if wanted
+if [ "$run_gradle" == "1" ]; then
+    echo y | runGradle genPatches createRelease # answer that question to overwrite working changes with yes
+fi
+
+# remove previous installations
 echo "Cleaning previous installations ..."
-rm -rf "build/tmp/fullRelease/*"
-mkdir -p "build/tmp/fullRelease"
+rm -rf "$build_dir/*"
 
-if [ "x$URL" != "x" ]; then
-    echo "Downloading patches..."
-    mkdir -p download
-    PATCH_PATH="`pwd`/download/carpet_patches.zip"
-    wget "$URL" -O "$PATCH_PATH" || { echo "download failed!" && exit 1; }
-else
-    PATCH_PATH="`pwd`/build/distributions/Carpetmod_dev.zip"
+# download the patches if wanted
+if [ "x$patch_url" != "x" ]; then
+    patch_zip="$download_dir/carpet_patches.zip"
+    rm -f "$patch_zip"
+    downloadIfNotHere "$patch_zip" "$patch_url" "Downloading patches..." "download failed!"
 fi
 
-echo "Copying server ..."
-BUILD_DIR="`pwd`/build/tmp/fullRelease"
-MC_JAR="$BUILD_DIR/minecraft_server.1.12.2.jar"
-if [ -f "$MC_JAR.orig" ]; then
-    cp "$MC_JAR.orig" "$MC_JAR"
+# get a 1.12.2 minecraft server jar
+echo "Getting Minecraft 1.12.2 server jar ..."
+if [ -f "$server_jar_gradle_cache" ]; then
+    cp "$server_jar_gradle_cache" "$carpet_jar"
 else
-    GRADLE_CACHE_JAR="$HOME/.gradle/caches/minecraft/net/minecraft/minecraft_server/1.12.2/minecraft_server-1.12.2.jar"
-    if [ -f "$GRADLE_CACHE_JAR" ]; then
-        cp "$GRADLE_CACHE_JAR" "$MC_JAR"
-    else
-        echo "Downloading server ..."
-        wget "https://launcher.mojang.com/v1/objects/886945bfb2b978778c3a0288fd7fab09d315b25f/server.jar" -O "$MC_JAR" || { echo "failed to download MC jar" && exit 1; }
-        cp "$MC_JAR" "$MC_JAR.orig"
-    fi
+    downloadIfNotHere "$server_jar_backup" "$server_jar_url"  "Downloading server ..." "failed to download server jar"
+    cp "$server_jar_backup" "$carpet_jar"
 fi
 
+# unzip the patches
 echo "Extracting patches ..."
-rm -rf "$BUILD_DIR/patches"
-mkdir -p "$BUILD_DIR/patches"
-unzip -q "$PATCH_PATH" -d "$BUILD_DIR/patches" || { echo "failed to extract patches!" && exit 1; }
+mkdir -p "$patch_dir"
+unzip -q "$patch_zip" -d "$patch_dir" || { echo "failed to extract patches!" && exit 1; }
 
+# patch the jar file
 echo "Patch work ..."
-pushd "$BUILD_DIR/patches"
-zip -q -u "$MC_JAR" `find . -name '*'`
-popd
+pushd "$patch_dir" > /dev/null
+zip -q -u "$carpet_jar" `find . -name '*'`
+popd > /dev/null
 
+# remove the extracted directory
 echo "Cleanup ..."
-pushd "$BUILD_DIR"
-rm -rf "patches"
-mv "$MC_JAR" "../../$carpet_name"
-popd
+rm -rf "$patch_dir"
 
-if [ "x$OUTFILE" != "x" ]; then
-    cp "build/$carpet_name" "$OUTFILE"
+# copy the jar to another location if wanted
+if [ "x$jar_copy_to" != "x" ]; then
+    cp "$carpet_jar" "$jar_copy_to"
 fi
 
-if [ "$TEST" = "1" ]; then
-    echo "Starting server ..."
-    rm -rf "test"
-    mkdir -p "test"
-    if [ "$EULA" = "1" ]; then
-        echo "eula=true" > "test/eula.txt"
+# deobfuscate the jar if wanted
+if [ "$additional_deobfuscated_jar" == "1" ]; then
+    downloadIfNotHere "$specialsource_jar" "$specialsource_jar_url" "Downloading SpecialSource ..." "failed to download special source"
+    runJava "$specialsource_jar" -i "$carpet_jar" -o "$carpet_jar_deob" -m "$mappings_file" -r
+fi
+
+# run a test if wanted
+if [ "$run_server" == "1" ]; then
+    pushd "$test_dir" > /dev/null
+
+    # delete all files or just some
+    if [ "$keep_configs" == "1" ]; then
+        rm -rf "carpet"
+        rm -rf "crash-reports"
+        rm -rf "logs"
+        rm -f "$test_jar"
+    else
+        rm -rf *
     fi
-    cp "build/$carpet_name" "test/$carpet_name"
-    pushd "test"
-    java -jar "$carpet_name" --nogui
-    popd
+
+    # copy the correct jar to the test folder
+    if [ "$additional_deobfuscated_jar" == "1" ]; then
+        cp "$carpet_jar_deob" "$test_jar"
+    else
+        cp "$carpet_jar" "$test_jar"
+    fi
+
+    # remove eula.txt, only write it when -e is passed
+    rm -f "eula.txt"
+    if [ "$eula" == "1" ]; then
+        echo "eula=true" > "eula.txt"
+    fi
+
+    # copy the server.properties.bak file to server.properties and replace some special strings
+    if [ "$copy_server_properties" == "1" ]; then
+        sed "s/BUILD/`date -Iseconds`/" server.properties.bak > server.properties
+    fi
+
+    # lanch java
+    echo "Starting server ..."
+    runJava "$test_jar" --nogui
+
+    popd > /dev/null
 fi
+
+# vim: ts=4 sw=4 et


### PR DESCRIPTION
All changes should not break any existing script that calls `mktest.sh`.

New help of `mktest.sh`:
```
./mktest.sh [-h] [-d URL] [-o OUTFILE] [-D] [-g] [-k] [-p] [-t] [-e]
 install and test Carpet patches

options:
 -h,--help             print this help and exit
 -d,--download URL     download patches from given URL
 -o,--outfile OUTFILE  output to given file
 -t,--test             run a test (run the server)
 -e,--eula             agree to Mojang EULA (see <https://account.mojang.com/documents/minecraft_eula>)
 -D,--deobf            create a deobfuscated jar in the build folder, and use that when to running a test
 -g,--gradle           run gradlew to compile carpet first
 -k,--keep             keep the world and config files of the server
 -p,--properties       copy server.properties.bak to server.properties and replace every instance of "BUILD" with the output of "date -Iseconds"
 ```
 Some information what the added options do:
 - `-D`: run [SpecialSource](https://github.com/md-5/SpecialSource) (from [here](https://repo.maven.apache.org/maven2/net/md-5/SpecialSource/1.11.0/), the shaded jar, ofc download it if needed) to create a additional jar that is deofuscated, also use that jar when running a test
 - `-g`: run `./gradlew genPatches createRelease` first to compile carpet (also answer that "overwrite working changes" question with `y`)
 - `-k`: don't delete everything in the `test` folder (this allows running the server with the same configs and world over and over again)
 - `-p`: copy `test/server.properties.bak` to `test/server.properties` and replace `BUILD` with the output of `date -Iseconds` (useful for the motd)

How to invoke `mktest.sh` when using another java:
 `JAVA_HOME=/c/Program\ Files/Eclipse\ Adoptium/jdk-8.0.322.6-hotspot/ ./mktest.sh -t -e -D -g -k -p`
 (I was using mingw in this case, to run the linux script on windows)
The script will invoke `$JAVA_HOME/bin/java` for running java. It will use `./gradlew` for calling gradle.


I added also the `download` folder to `.gitignore`, as i don't think anybody would like to upload their downloaded patches.