### PR TITLE
Add LiquidPopulation logger

### DIFF
--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -999,6 +999,12 @@ public class CarpetSettings
     @Rule(desc = "Removes tnt applying velocity to other entities.", category = CREATIVE)
     public static boolean removeTNTVelocity = false;
 
+    @Rule(desc = "Minimum height to log \"liquidPopulation\" logger", category = {EXPERIMENTAL, FEATURE}, options = {"0","62","100"})
+    public static int logLiquidPopulationMinHeight = 62;
+
+    @Rule(desc = "Maximum height to log \"liquidPopulation\" logger", category = {EXPERIMENTAL, FEATURE}, options = {"0","73","100", "256"})
+    public static int logLiquidPopulationMaxHeight = 256;
+
     // ===== API ===== //
 
     /**

--- a/carpetmodSrc/carpet/logging/LoggerRegistry.java
+++ b/carpetmodSrc/carpet/logging/LoggerRegistry.java
@@ -48,6 +48,7 @@ public class LoggerRegistry
     public static boolean __items;
     public static boolean __rng;
     public static boolean __explosions;
+    public static boolean __liquidPopulation;
     public static boolean __recipes;
     public static boolean __damageDebug;
     public static boolean __invisDebug;
@@ -68,6 +69,7 @@ public class LoggerRegistry
         registerLogger("items",new Logger(server, "items", "brief", new String[]{"brief", "full"}, LogHandler.CHAT));
         registerLogger("rng", new Logger(server, "rng", null, null, LogHandler.CHAT));
         registerLogger("explosions", new Logger(server, "explosions", "compact", new String[]{"brief", "full", "compact"}, LogHandler.CHAT));
+        registerLogger("liquidPopulation", new Logger(server, "liquidPopulation", "all", new String[]{"all","players","me"}, LogHandler.CHAT));
 
         registerLogger("autosave", new Logger(server, "autosave", null, null, LogHandler.HUD));
         registerLogger("tps", new Logger(server, "tps", null, null, LogHandler.HUD));

--- a/patches/net/minecraft/world/biome/BiomeDecorator.java.patch
+++ b/patches/net/minecraft/world/biome/BiomeDecorator.java.patch
@@ -1,0 +1,44 @@
+--- ../src-base/minecraft/net/minecraft/world/biome/BiomeDecorator.java
++++ ../src-work/minecraft/net/minecraft/world/biome/BiomeDecorator.java
+@@ -1,11 +1,16 @@
+ package net.minecraft.world.biome;
+ 
+ import java.util.Random;
++
++import carpet.logging.LoggerRegistry;
++import carpet.utils.Messenger;
+ import net.minecraft.block.BlockFlower;
+ import net.minecraft.block.BlockStone;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.init.Blocks;
+ import net.minecraft.util.math.BlockPos;
++import net.minecraft.util.text.ITextComponent;
++import net.minecraft.util.text.TextFormatting;
+ import net.minecraft.world.World;
+ import net.minecraft.world.gen.ChunkGeneratorSettings;
+ import net.minecraft.world.gen.feature.WorldGenAbstractTree;
+@@ -66,6 +71,12 @@
+ 
+     public void func_180292_a(World p_180292_1_, Random p_180292_2_, Biome p_180292_3_, BlockPos p_180292_4_)
+     {
++        if(LoggerRegistry.__liquidPopulation) {
++            LoggerRegistry.getLogger("liquidPopulation").logNoCommand(()-> new ITextComponent[]{
++                    Messenger.s(null, TextFormatting.YELLOW + "Starting decoration of chunk: " + TextFormatting.AQUA + p_180292_4_.func_177958_n() / 16 + " " + p_180292_4_.func_177952_p() / 16)
++            });
++        }
++
+         if (this.field_185425_a)
+         {
+             throw new RuntimeException("Already decorating");
+@@ -88,6 +99,11 @@
+             this.func_150513_a(p_180292_3_, p_180292_1_, p_180292_2_);
+             this.field_185425_a = false;
+         }
++        if(LoggerRegistry.__liquidPopulation) {
++            LoggerRegistry.getLogger("liquidPopulation").logNoCommand(()-> new ITextComponent[]{
++                    Messenger.s(null, TextFormatting.YELLOW + "Finished decoration of chunk: " + TextFormatting.AQUA + p_180292_4_.func_177958_n() / 16 + " " + p_180292_4_.func_177952_p() / 16)
++            });
++        }
+     }
+ 
+     protected void func_150513_a(Biome p_150513_1_, World p_150513_2_, Random p_150513_3_)

--- a/patches/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -1,6 +1,26 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java
-@@ -25,6 +25,10 @@
+@@ -3,6 +3,10 @@
+ import java.util.List;
+ import java.util.Random;
+ import javax.annotation.Nullable;
++
++import carpet.CarpetSettings;
++import carpet.logging.LoggerRegistry;
++import carpet.utils.Messenger;
+ import net.minecraft.block.BlockFalling;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+@@ -12,6 +16,8 @@
+ import net.minecraft.util.math.BlockPos;
+ import net.minecraft.util.math.ChunkPos;
+ import net.minecraft.util.math.MathHelper;
++import net.minecraft.util.text.ITextComponent;
++import net.minecraft.util.text.TextFormatting;
+ import net.minecraft.world.World;
+ import net.minecraft.world.biome.Biome;
+ import net.minecraft.world.chunk.Chunk;
+@@ -25,6 +31,10 @@
  import net.minecraft.world.gen.feature.WorldGenerator;
  import net.minecraft.world.gen.structure.MapGenNetherBridge;
  
@@ -11,7 +31,46 @@
  public class ChunkGeneratorHell implements IChunkGenerator
  {
      protected static final IBlockState field_185940_a = Blocks.field_150350_a.func_176223_P();
-@@ -455,4 +459,12 @@
+@@ -209,6 +219,14 @@
+ 
+                                     if (j1 < i && (iblockstate == null || iblockstate.func_185904_a() == Material.field_151579_a))
+                                     {
++                                        if (LoggerRegistry.__liquidPopulation && j1 >= CarpetSettings.logLiquidPopulationMinHeight && j1 <= CarpetSettings.logLiquidPopulationMaxHeight) {
++                                            TextFormatting color =TextFormatting.RED;
++                                            String pos = "x: " + k + " y: " + j1 + " z: " + j;
++                                            LoggerRegistry.getLogger("liquidPopulation").logNoCommand(()-> new ITextComponent[]{
++                                                    Messenger.s(null, TextFormatting.GREEN + "- Pocket of " + color + "LAVA" + TextFormatting.GREEN + " tried to generate in: " +
++                                                            TextFormatting.AQUA + pos)
++                                            });
++                                        }
+                                         iblockstate = field_185943_d;
+                                     }
+ 
+@@ -246,6 +264,11 @@
+ 
+     public Chunk func_185932_a(int p_185932_1_, int p_185932_2_)
+     {
++        if(LoggerRegistry.__liquidPopulation) {
++            LoggerRegistry.getLogger("liquidPopulation").logNoCommand(()-> new ITextComponent[]{
++                    Messenger.s(null, TextFormatting.YELLOW + "Starting decoration of chunk: " + TextFormatting.AQUA + p_185932_1_ + " " + p_185932_2_)
++            });
++        }
+         this.field_185954_p.setSeed((long)p_185932_1_ * 341873128712L + (long)p_185932_2_ * 132897987541L);
+         ChunkPrimer chunkprimer = new ChunkPrimer();
+         this.func_185936_a(p_185932_1_, p_185932_2_, chunkprimer);
+@@ -267,6 +290,11 @@
+         }
+ 
+         chunk.func_76613_n();
++        if(LoggerRegistry.__liquidPopulation) {
++            LoggerRegistry.getLogger("liquidPopulation").logNoCommand(()-> new ITextComponent[]{
++                    Messenger.s(null, TextFormatting.YELLOW + "Finished decoration of chunk: " + TextFormatting.AQUA + p_185932_1_ + " " +p_185932_2_)
++            });
++        }
+         return chunk;
+     }
+ 
+@@ -455,4 +483,12 @@
      {
          this.field_73172_c.func_186125_a(this.field_185952_n, p_180514_2_, p_180514_3_, (ChunkPrimer)null);
      }

--- a/patches/net/minecraft/world/gen/feature/WorldGenHellLava.java.patch
+++ b/patches/net/minecraft/world/gen/feature/WorldGenHellLava.java.patch
@@ -1,0 +1,34 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenHellLava.java
++++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenHellLava.java
+@@ -1,11 +1,17 @@
+ package net.minecraft.world.gen.feature;
+ 
+ import java.util.Random;
++
++import carpet.CarpetSettings;
++import carpet.logging.LoggerRegistry;
++import carpet.utils.Messenger;
+ import net.minecraft.block.Block;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.init.Blocks;
+ import net.minecraft.util.math.BlockPos;
++import net.minecraft.util.text.ITextComponent;
++import net.minecraft.util.text.TextFormatting;
+ import net.minecraft.world.World;
+ 
+ public class WorldGenHellLava extends WorldGenerator
+@@ -87,6 +93,13 @@
+ 
+             if (!this.field_94524_b && i == 4 && j == 1 || i == 5)
+             {
++
++                if (LoggerRegistry.__liquidPopulation && p_180709_3_.func_177956_o() >= CarpetSettings.logLiquidPopulationMinHeight && p_180709_3_.func_177956_o() <= CarpetSettings.logLiquidPopulationMaxHeight) {
++                    LoggerRegistry.getLogger("liquidPopulation").logNoCommand(()-> new ITextComponent[]{
++                            Messenger.s(null, TextFormatting.GREEN + "- Pocket of " + TextFormatting.RED + "LAVA" + TextFormatting.GREEN + " tried to generate in: " +
++                                    TextFormatting.AQUA + p_180709_3_)
++                    });
++                }
+                 IBlockState iblockstate = this.field_150553_a.func_176223_P();
+                 p_180709_1_.func_180501_a(p_180709_3_, iblockstate, 2);
+                 p_180709_1_.func_189507_a(p_180709_3_, iblockstate, p_180709_2_);

--- a/patches/net/minecraft/world/gen/feature/WorldGenLiquids.java.patch
+++ b/patches/net/minecraft/world/gen/feature/WorldGenLiquids.java.patch
@@ -1,0 +1,34 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenLiquids.java
++++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenLiquids.java
+@@ -1,11 +1,17 @@
+ package net.minecraft.world.gen.feature;
+ 
+ import java.util.Random;
++
++import carpet.CarpetSettings;
++import carpet.logging.LoggerRegistry;
++import carpet.utils.Messenger;
+ import net.minecraft.block.Block;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.init.Blocks;
+ import net.minecraft.util.math.BlockPos;
++import net.minecraft.util.text.ITextComponent;
++import net.minecraft.util.text.TextFormatting;
+ import net.minecraft.world.World;
+ 
+ public class WorldGenLiquids extends WorldGenerator
+@@ -19,6 +25,13 @@
+ 
+     public boolean func_180709_b(World p_180709_1_, Random p_180709_2_, BlockPos p_180709_3_)
+     {
++        if (LoggerRegistry.__liquidPopulation && p_180709_3_.func_177956_o() >= CarpetSettings.logLiquidPopulationMinHeight && p_180709_3_.func_177956_o() <= CarpetSettings.logLiquidPopulationMaxHeight) {
++            TextFormatting color = field_150521_a.equals(Blocks.field_150356_k) ? TextFormatting.RED : TextFormatting.BLUE;
++            LoggerRegistry.getLogger("liquidPopulation").logNoCommand(()-> new ITextComponent[]{
++                    Messenger.s(null, TextFormatting.GREEN + "- Pocket of " + color + field_150521_a + TextFormatting.GREEN + " tried to generate in: " +
++                            TextFormatting.AQUA + p_180709_3_)
++            });
++        }
+         if (p_180709_1_.func_180495_p(p_180709_3_.func_177984_a()).func_177230_c() != Blocks.field_150348_b)
+         {
+             return false;


### PR DESCRIPTION
> Note: this is a remake of the pull request #172 because I updated the fork structure and mess up the things a little bit
> Also had been added nether compatibility as asked in the pull request

Simple logger for decoration of liquids. Mainly made by [angarn](https://github.com/zAngarn), I just remarked some parts and optimize the code. 

Useful when you are working with async lines and chunk swaps.


```
/log LiquidPopulation
/carpet logLiquidPopulationtMinHeight [int]
/carpet logLiquidPopulationMaxHeight [int]
```
## Showcase
- Example with logLiquidPopulationMinHeight 64 and logLiquidPopulationMaxHeight 70


![2022-07-25_23 58 00](https://user-images.githubusercontent.com/48159556/180888866-ef9e73f8-63cc-47a0-87a3-e01a043bd235.png)

- Finally [here](https://github.com/luisch444/carpetmod112/releases/tag/test_01) is the release of this branch if anyone needs this rule before is merged.