### PR TITLE
Fake players firing arrows when using "stop" command

### DIFF
--- a/carpetmodSrc/carpet/commands/CommandPlayer.java
+++ b/carpetmodSrc/carpet/commands/CommandPlayer.java
@@ -113,6 +113,7 @@ public class CommandPlayer extends CommandCarpetBase
         if ("stop".equalsIgnoreCase(action))
         {
             player.actionPack.stop();
+            player.stopActiveHand();
             return;
         }
         if ("drop".equalsIgnoreCase(action))


### PR DESCRIPTION
Added `stopActiveHand()` to `stop` command to make fake players fire arrows when bow is charged
